### PR TITLE
Merge tokens

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -7,7 +7,7 @@ skip-lint = false
 [programs.localnet]
 autocrat_migrator = "migkwAXrXFN34voCYQUhFQBXZJjHrWnpEXbSGTqZdB3"
 autocrat_v0 = "metaX99LHn3A7Gr7VAcCfXhpfocvpMpqQ3eyp3PGUUq"
-conditional_vault = "vaU1tVLj8RFk7mNj1BxqgAsMKKaL8UvEUHvU3tdbZPe"
+conditional_vault = "vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP"
 
 [registry]
 url = "https://api.apr.dev"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and what they do can be found at [docs.themetadao.org](https://docs.themetadao.o
 ## Scripts
 
 The scripts folder contains a few scripts that you can use to interact with the Meta-DAO.
-Today, the only way to create proposals is via script. You can do this by modifying the 
+Today, the only way to create proposals is via script. You can do this by modifying the
 `initializeProposal.ts` script and replacing its `pubkey`, `accounts`, and `data` with the
 SVM instruction that you want to use in your proposal.
 
@@ -17,12 +17,13 @@ either devnet, mainnet, or (recommended) an RPC URL.
 
 ## Deployments
 
-| program           | tag | program ID                                  |
-| ----------------- | --- | ------------------------------------------- |
-| autocrat_v0       | v0.1| metaX99LHn3A7Gr7VAcCfXhpfocvpMpqQ3eyp3PGUUq |
-| autocrat_migrator | v0.1| migkwAXrXFN34voCYQUhFQBXZJjHrWnpEXbSGTqZdB3 |
-| autocrat_v0       | v0  | meta3cxKzFBmWYgCVozmvCQAS3y9b3fGxrG9HkHL7Wi |
-| conditional_vault | v0  | vaU1tVLj8RFk7mNj1BxqgAsMKKaL8UvEUHvU3tdbZPe |
+| program           | tag  | program ID                                  |
+| ----------------- | ---- | ------------------------------------------- |
+| conditional_vault | v0.1 | vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP |
+| autocrat_v0       | v0.1 | metaX99LHn3A7Gr7VAcCfXhpfocvpMpqQ3eyp3PGUUq |
+| autocrat_migrator | v0.1 | migkwAXrXFN34voCYQUhFQBXZJjHrWnpEXbSGTqZdB3 |
+| autocrat_v0       | v0   | meta3cxKzFBmWYgCVozmvCQAS3y9b3fGxrG9HkHL7Wi |
+| conditional_vault | v0   | vaU1tVLj8RFk7mNj1BxqgAsMKKaL8UvEUHvU3tdbZPe |
 
 All programs are immutable and verifiable, and have been verified with the OtterSec API.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ either devnet, mainnet, or (recommended) an RPC URL.
 
 | program           | tag  | program ID                                  |
 | ----------------- | ---- | ------------------------------------------- |
-| conditional_vault | v0.1 | vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP |
+| conditional_vault | v0.2 | vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP |
 | autocrat_v0       | v0.1 | metaX99LHn3A7Gr7VAcCfXhpfocvpMpqQ3eyp3PGUUq |
 | autocrat_migrator | v0.1 | migkwAXrXFN34voCYQUhFQBXZJjHrWnpEXbSGTqZdB3 |
 | autocrat_v0       | v0   | meta3cxKzFBmWYgCVozmvCQAS3y9b3fGxrG9HkHL7Wi |

--- a/programs/conditional_vault/src/lib.rs
+++ b/programs/conditional_vault/src/lib.rs
@@ -155,6 +155,104 @@ pub mod conditional_vault {
         Ok(())
     }
 
+    pub fn merge_conditional_tokens_for_underlying_tokens(
+        ctx: Context<RedeemConditionalTokensForUnderlyingTokens>, amount: u64
+    ) -> Result<()> {
+        let accs = &ctx.accounts;
+
+        let vault = &accs.vault;
+        let vault_status = vault.status;
+        require!(vault_status == VaultStatus::Active, ErrorCode::VaultAlreadySettled);
+
+        // Store Pre-operation Balances
+        let pre_user_conditional_on_finalize_balance = ctx
+        .accounts
+        .user_conditional_on_finalize_token_account
+        .amount;
+        let pre_user_conditional_on_revert_balance =
+            ctx.accounts.user_conditional_on_revert_token_account.amount;
+        let pre_vault_underlying_balance = ctx.accounts.vault_underlying_token_account.amount;
+        let pre_finalize_mint_supply = ctx.accounts.conditional_on_finalize_token_mint.supply;
+        let pre_revert_mint_supply = ctx.accounts.conditional_on_revert_token_mint.supply;
+
+        let seeds = generate_vault_seeds!(vault);
+        let signer = &[&seeds[..]];
+
+        // burn `amount` from both token accounts
+        token::burn(
+            CpiContext::new(
+                accs.token_program.to_account_info(),
+                Burn {
+                    mint: accs.conditional_on_finalize_token_mint.to_account_info(),
+                    from: accs
+                        .user_conditional_on_finalize_token_account
+                        .to_account_info(),
+                    authority: accs.authority.to_account_info(),
+                },
+            ),
+            amount,
+        )?;
+
+        token::burn(
+            CpiContext::new(
+                accs.token_program.to_account_info(),
+                Burn {
+                    mint: accs.conditional_on_revert_token_mint.to_account_info(),
+                    from: accs
+                        .user_conditional_on_revert_token_account
+                        .to_account_info(),
+                    authority: accs.authority.to_account_info(),
+                },
+            ),
+            amount,
+        )?;
+
+        // Transfer `amount` from vault to user
+        token::transfer(
+            CpiContext::new_with_signer(
+                accs.token_program.to_account_info(),
+                Transfer {
+                    from: accs.vault_underlying_token_account.to_account_info(),
+                    to: accs.user_underlying_token_account.to_account_info(),
+                    authority: accs.vault.to_account_info(),
+                },
+                signer,
+            ),
+            amount,
+        )?;
+
+        // Reload Accounts to Reflect Changes
+        ctx.accounts.user_conditional_on_finalize_token_account.reload()?;
+        ctx.accounts.user_conditional_on_revert_token_account.reload()?;
+        ctx.accounts.vault_underlying_token_account.reload()?;
+        ctx.accounts.conditional_on_finalize_token_mint.reload()?;
+        ctx.accounts.conditional_on_revert_token_mint.reload()?;
+
+        // Check post-operation balances
+        let post_user_conditional_on_finalize_balance = ctx
+            .accounts
+            .user_conditional_on_finalize_token_account
+            .amount;
+        let post_user_conditional_on_revert_balance =
+            ctx.accounts.user_conditional_on_revert_token_account.amount;
+        let post_vault_underlying_balance = ctx.accounts.vault_underlying_token_account.amount;
+        let post_finalize_mint_supply = ctx.accounts.conditional_on_finalize_token_mint.supply;
+        let post_revert_mint_supply = ctx.accounts.conditional_on_revert_token_mint.supply;
+
+        // Check that the user's conditional token balances are unchanged (since we're not necessarily burning all tokens)
+        require_eq!(post_user_conditional_on_finalize_balance, pre_user_conditional_on_finalize_balance - amount);
+        require_eq!(post_user_conditional_on_revert_balance, pre_user_conditional_on_revert_balance - amount);
+
+        // Check that the mint supplies have been reduced by the burned amounts
+        require_eq!(post_finalize_mint_supply, pre_finalize_mint_supply - amount);
+        require_eq!(post_revert_mint_supply, pre_revert_mint_supply - amount);
+
+        // Check that the vault's underlying balance has been reduced by the transferred amount
+        require_eq!(post_vault_underlying_balance, pre_vault_underlying_balance - amount);
+
+        Ok(())
+    }
+
     pub fn mint_conditional_tokens(ctx: Context<MintConditionalTokens>, amount: u64) -> Result<()> {
         let accs = &ctx.accounts;
 

--- a/programs/conditional_vault/src/lib.rs
+++ b/programs/conditional_vault/src/lib.rs
@@ -156,19 +156,23 @@ pub mod conditional_vault {
     }
 
     pub fn merge_conditional_tokens_for_underlying_tokens(
-        ctx: Context<MergeConditionalTokensForUnderlyingTokens>, amount: u64
+        ctx: Context<MergeConditionalTokensForUnderlyingTokens>,
+        amount: u64,
     ) -> Result<()> {
         let accs = &ctx.accounts;
 
         let vault = &accs.vault;
         let vault_status = vault.status;
-        require!(vault_status == VaultStatus::Active, ErrorCode::VaultAlreadySettled);
+        require!(
+            vault_status == VaultStatus::Active,
+            ErrorCode::VaultAlreadySettled
+        );
 
         // Store Pre-operation Balances
         let pre_user_conditional_on_finalize_balance = ctx
-        .accounts
-        .user_conditional_on_finalize_token_account
-        .amount;
+            .accounts
+            .user_conditional_on_finalize_token_account
+            .amount;
         let pre_user_conditional_on_revert_balance =
             ctx.accounts.user_conditional_on_revert_token_account.amount;
         let pre_vault_underlying_balance = ctx.accounts.vault_underlying_token_account.amount;
@@ -222,8 +226,12 @@ pub mod conditional_vault {
         )?;
 
         // Reload Accounts to Reflect Changes
-        ctx.accounts.user_conditional_on_finalize_token_account.reload()?;
-        ctx.accounts.user_conditional_on_revert_token_account.reload()?;
+        ctx.accounts
+            .user_conditional_on_finalize_token_account
+            .reload()?;
+        ctx.accounts
+            .user_conditional_on_revert_token_account
+            .reload()?;
         ctx.accounts.vault_underlying_token_account.reload()?;
         ctx.accounts.conditional_on_finalize_token_mint.reload()?;
         ctx.accounts.conditional_on_revert_token_mint.reload()?;
@@ -240,15 +248,24 @@ pub mod conditional_vault {
         let post_revert_mint_supply = ctx.accounts.conditional_on_revert_token_mint.supply;
 
         // Check that the user's conditional token balances are unchanged (since we're not necessarily burning all tokens)
-        require_eq!(post_user_conditional_on_finalize_balance, pre_user_conditional_on_finalize_balance - amount);
-        require_eq!(post_user_conditional_on_revert_balance, pre_user_conditional_on_revert_balance - amount);
+        require_eq!(
+            post_user_conditional_on_finalize_balance,
+            pre_user_conditional_on_finalize_balance - amount
+        );
+        require_eq!(
+            post_user_conditional_on_revert_balance,
+            pre_user_conditional_on_revert_balance - amount
+        );
 
         // Check that the mint supplies have been reduced by the burned amounts
         require_eq!(post_finalize_mint_supply, pre_finalize_mint_supply - amount);
         require_eq!(post_revert_mint_supply, pre_revert_mint_supply - amount);
 
         // Check that the vault's underlying balance has been reduced by the transferred amount
-        require_eq!(post_vault_underlying_balance, pre_vault_underlying_balance - amount);
+        require_eq!(
+            post_vault_underlying_balance,
+            pre_vault_underlying_balance - amount
+        );
 
         Ok(())
     }

--- a/programs/conditional_vault/src/lib.rs
+++ b/programs/conditional_vault/src/lib.rs
@@ -162,11 +162,6 @@ pub mod conditional_vault {
         let accs = &ctx.accounts;
 
         let vault = &accs.vault;
-        let vault_status = vault.status;
-        require!(
-            vault_status == VaultStatus::Active,
-            ErrorCode::VaultAlreadySettled
-        );
 
         // Store Pre-operation Balances
         let pre_user_conditional_on_finalize_balance = ctx

--- a/programs/conditional_vault/src/lib.rs
+++ b/programs/conditional_vault/src/lib.rs
@@ -23,7 +23,7 @@ security_txt! {
     acknowledgements: "DCF = (CF1 / (1 + r)^1) + (CF2 / (1 + r)^2) + ... (CFn / (1 + r)^n)"
 }
 
-declare_id!("vaU1tVLj8RFk7mNj1BxqgAsMKKaL8UvEUHvU3tdbZPe");
+declare_id!("vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP");
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, PartialEq, Eq)]
 pub enum VaultStatus {

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -41,7 +41,7 @@ const AUTOCRAT_PROGRAM_ID = new PublicKey(
   "metaX99LHn3A7Gr7VAcCfXhpfocvpMpqQ3eyp3PGUUq"
 );
 const CONDITIONAL_VAULT_PROGRAM_ID = new PublicKey(
-  "vaU1tVLj8RFk7mNj1BxqgAsMKKaL8UvEUHvU3tdbZPe"
+  "vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP"
 );
 const OPENBOOK_TWAP_PROGRAM_ID = new PublicKey(
   "TWAPrdhADy2aTKN5iFZtNnkQYXERD9NvKjPFVPMSCNN"

--- a/tests/autocratV0.ts
+++ b/tests/autocratV0.ts
@@ -8,7 +8,7 @@ import {
   PlaceOrderArgs,
   Side,
   OrderType,
-  SelfTradeBehavior
+  SelfTradeBehavior,
 } from "@openbook-dex/openbook-v2";
 import { assert } from "chai";
 import {
@@ -68,7 +68,7 @@ const AUTOCRAT_PROGRAM_ID = new PublicKey(
 );
 
 const CONDITIONAL_VAULT_PROGRAM_ID = new PublicKey(
-  "vaU1tVLj8RFk7mNj1BxqgAsMKKaL8UvEUHvU3tdbZPe"
+  "vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP"
 );
 
 const OPENBOOK_TWAP_PROGRAM_ID = new PublicKey(

--- a/tests/conditionalVault.ts
+++ b/tests/conditionalVault.ts
@@ -42,7 +42,7 @@ export type Signer = anchor.web3.Signer;
 export type Keypair = anchor.web3.Keypair;
 
 const CONDITIONAL_VAULT_PROGRAM_ID = new PublicKey(
-  "vaU1tVLj8RFk7mNj1BxqgAsMKKaL8UvEUHvU3tdbZPe"
+  "vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP"
 );
 
 const METADATA_URI =


### PR DESCRIPTION
Adds the ability for users to merge pass/fail tokens back to their underlying token before the end of the market.

It was lazy but essentially the logic is all copied and pasted and minorly modified from the existing `redeem` function and tests.

Small note: I chose to take an additive approach to the program. But it would have been possible to reuse the account struct `RedeemConditionalTokensForUnderlyingTokens` except that it has a constraint involving the `vault status` which could possibly be inside the `redeem` function as a `require(vaultStatus, Finalized)` check. Rather than changing the existing code though, I just copy/pasted to a new account struct and modified the constraint.