### PR TITLE
Update program IDs for new deployment

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -5,7 +5,7 @@ seeds = false
 skip-lint = false
 
 [programs.localnet]
-autocrat_migrator = "migkwAXrXFN34voCYQUhFQBXZJjHrWnpEXbSGTqZdB3"
+autocrat_migrator = "MigRDW6uxyNMDBD8fX2njCRyJC4YZk2Rx9pDUZiAESt"
 autocrat_v0 = "metaRK9dUBnrAdZN6uUDKvxBVKW5pyCbPVmLtUZwtBp"
 conditional_vault = "vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP"
 

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -6,7 +6,7 @@ skip-lint = false
 
 [programs.localnet]
 autocrat_migrator = "migkwAXrXFN34voCYQUhFQBXZJjHrWnpEXbSGTqZdB3"
-autocrat_v0 = "metaX99LHn3A7Gr7VAcCfXhpfocvpMpqQ3eyp3PGUUq"
+autocrat_v0 = "metaRK9dUBnrAdZN6uUDKvxBVKW5pyCbPVmLtUZwtBp"
 conditional_vault = "vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP"
 
 [registry]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ either devnet, mainnet, or (recommended) an RPC URL.
 | program           | tag  | program ID                                  |
 | ----------------- | ---- | ------------------------------------------- |
 | autocrat_v0       | v0.2 | metaRK9dUBnrAdZN6uUDKvxBVKW5pyCbPVmLtUZwtBp |
+| autocrat_migrator | v0.2 | MigRDW6uxyNMDBD8fX2njCRyJC4YZk2Rx9pDUZiAESt |
 | conditional_vault | v0.2 | vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP |
 | autocrat_v0       | v0.1 | metaX99LHn3A7Gr7VAcCfXhpfocvpMpqQ3eyp3PGUUq |
 | autocrat_migrator | v0.1 | migkwAXrXFN34voCYQUhFQBXZJjHrWnpEXbSGTqZdB3 |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ either devnet, mainnet, or (recommended) an RPC URL.
 
 | program           | tag  | program ID                                  |
 | ----------------- | ---- | ------------------------------------------- |
+| autocrat_v0       | v0.2 | metaRK9dUBnrAdZN6uUDKvxBVKW5pyCbPVmLtUZwtBp |
 | conditional_vault | v0.2 | vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP |
 | autocrat_v0       | v0.1 | metaX99LHn3A7Gr7VAcCfXhpfocvpMpqQ3eyp3PGUUq |
 | autocrat_migrator | v0.1 | migkwAXrXFN34voCYQUhFQBXZJjHrWnpEXbSGTqZdB3 |

--- a/programs/autocrat_migrator/src/lib.rs
+++ b/programs/autocrat_migrator/src/lib.rs
@@ -5,7 +5,7 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program;
 use anchor_spl::token::{transfer, Token, TokenAccount, Transfer};
 
-declare_id!("migkwAXrXFN34voCYQUhFQBXZJjHrWnpEXbSGTqZdB3");
+declare_id!("MigRDW6uxyNMDBD8fX2njCRyJC4YZk2Rx9pDUZiAESt");
 
 #[program]
 pub mod autocrat_migrator {

--- a/programs/autocrat_v0/src/lib.rs
+++ b/programs/autocrat_v0/src/lib.rs
@@ -24,7 +24,7 @@ security_txt! {
     acknowledgements: "DCF = (CF1 / (1 + r)^1) + (CF2 / (1 + r)^2) + ... (CFn / (1 + r)^n)"
 }
 
-declare_id!("metaX99LHn3A7Gr7VAcCfXhpfocvpMpqQ3eyp3PGUUq");
+declare_id!("metaRK9dUBnrAdZN6uUDKvxBVKW5pyCbPVmLtUZwtBp");
 
 pub const SLOTS_PER_10_SECS: u64 = 25;
 pub const THREE_DAYS_IN_SLOTS: u64 = 3 * 24 * 60 * 6 * SLOTS_PER_10_SECS;

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -63,7 +63,7 @@ export const PROPH3t_PUBKEY = new PublicKey(
   "65U66fcYuNfqN12vzateJhZ4bgDuxFWN9gMwraeQKByg"
 );
 const AUTOCRAT_MIGRATOR_PROGRAM_ID = new PublicKey(
-  "migkwAXrXFN34voCYQUhFQBXZJjHrWnpEXbSGTqZdB3"
+  "MigRDW6uxyNMDBD8fX2njCRyJC4YZk2Rx9pDUZiAESt"
 );
 
 const MPL_TOKEN_METADATA_PROGRAM_ID = toWeb3JsPublicKey(

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -38,7 +38,7 @@ const OpenbookTwapIDL: OpenbookTwap = require("../tests/fixtures/openbook_twap.j
 const AutocratMigratorIDL: AutocratMigrator = require("../target/idl/autocrat_migrator.json");
 
 const AUTOCRAT_PROGRAM_ID = new PublicKey(
-  "metaX99LHn3A7Gr7VAcCfXhpfocvpMpqQ3eyp3PGUUq"
+  "metaRK9dUBnrAdZN6uUDKvxBVKW5pyCbPVmLtUZwtBp"
 );
 const CONDITIONAL_VAULT_PROGRAM_ID = new PublicKey(
   "vAuLTQjV5AZx5f3UgE75wcnkxnQowWxThn1hGjfCVwP"

--- a/tests/autocratV0.ts
+++ b/tests/autocratV0.ts
@@ -63,7 +63,7 @@ type ProposalInstruction = anchor.IdlTypes<AutocratV0>["ProposalInstruction"];
 
 // this test file isn't 'clean' or DRY or whatever; sorry!
 const AUTOCRAT_PROGRAM_ID = new PublicKey(
-  "metaX99LHn3A7Gr7VAcCfXhpfocvpMpqQ3eyp3PGUUq"
+  "metaRK9dUBnrAdZN6uUDKvxBVKW5pyCbPVmLtUZwtBp"
 );
 
 const CONDITIONAL_VAULT_PROGRAM_ID = new PublicKey(

--- a/tests/autocratV0.ts
+++ b/tests/autocratV0.ts
@@ -79,7 +79,7 @@ const OPENBOOK_PROGRAM_ID = new PublicKey(
 );
 
 const AUTOCRAT_MIGRATOR_PROGRAM_ID = new PublicKey(
-  "migkwAXrXFN34voCYQUhFQBXZJjHrWnpEXbSGTqZdB3"
+  "MigRDW6uxyNMDBD8fX2njCRyJC4YZk2Rx9pDUZiAESt"
 );
 
 describe("autocrat_v0", async function () {

--- a/tests/migrator.ts
+++ b/tests/migrator.ts
@@ -10,7 +10,7 @@ import { assert } from "chai";
 import { startAnchor } from "solana-bankrun";
 
 const AUTOCRAT_MIGRATOR_PROGRAM_ID = new PublicKey(
-  "migkwAXrXFN34voCYQUhFQBXZJjHrWnpEXbSGTqZdB3"
+  "MigRDW6uxyNMDBD8fX2njCRyJC4YZk2Rx9pDUZiAESt"
 );
 
 import { AutocratMigrator } from "../target/types/autocrat_migrator";


### PR DESCRIPTION
Autocrat and migrator also need new program IDs. The others have already been updated.