### PR TITLE
Add security checks that `dao.treasury == dao_treasury`

### DIFF
--- a/programs/autocrat_v0/src/lib.rs
+++ b/programs/autocrat_v0/src/lib.rs
@@ -390,10 +390,7 @@ pub mod autocrat_v0 {
         Ok(())
     }
 
-    pub fn update_dao(
-        ctx: Context<UpdateDao>,
-        dao_params: UpdateDaoParams,
-    ) -> Result<()> {
+    pub fn update_dao(ctx: Context<UpdateDao>, dao_params: UpdateDaoParams) -> Result<()> {
         let dao = &mut ctx.accounts.dao;
 
         if let Some(pass_threshold_bps) = dao_params.pass_threshold_bps {
@@ -450,7 +447,10 @@ pub struct InitializeDAO<'info> {
 pub struct InitializeProposal<'info> {
     #[account(zero, signer)]
     pub proposal: Box<Account<'info, Proposal>>,
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = dao.treasury == dao_treasury.key() @ AutocratError::DaoTreasuryMismatch
+    )]
     pub dao: Account<'info, DAO>,
     /// CHECK: never read
     #[account(
@@ -491,6 +491,9 @@ pub struct FinalizeProposal<'info> {
     pub proposal: Account<'info, Proposal>,
     pub openbook_twap_pass_market: Account<'info, TWAPMarket>,
     pub openbook_twap_fail_market: Account<'info, TWAPMarket>,
+    #[account(
+        constraint = dao.treasury == dao_treasury.key() @ AutocratError::DaoTreasuryMismatch
+    )]
     pub dao: Box<Account<'info, DAO>>,
     #[account(mut)]
     pub base_vault: Box<Account<'info, ConditionalVaultAccount>>,
@@ -518,7 +521,10 @@ pub struct UpdateDaoParams {
 
 #[derive(Accounts)]
 pub struct UpdateDao<'info> {
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = dao.treasury == dao_treasury.key() @ AutocratError::DaoTreasuryMismatch
+    )]
     pub dao: Account<'info, DAO>,
     /// CHECK: never read
     #[account(
@@ -570,4 +576,6 @@ pub enum AutocratError {
     ProposalAlreadyFinalized,
     #[msg("A conditional vault has an invalid nonce. A nonce should encode pass = 0 / fail = 1 in its most significant bit, base = 0 / quote = 1 in its second most significant bit, and the proposal number in least significant 32 bits")]
     InvalidVaultNonce,
+    #[msg("Mismatch between DAO treasury and PDA signer")]
+    DaoTreasuryMismatch,
 }


### PR DESCRIPTION
Shouldn't be needed, but still worth double-checking