### PR TITLE
fix: scripts for conditional metadata upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ SVM instruction that you want to use in your proposal.
 Then, run `anchor run propose --provider.cluster CLUSTER`, where `CLUSTER` is replaced with
 either devnet, mainnet, or (recommended) an RPC URL.
 
+### Initialize Proposal
+
+The initialize proposal script initializes conditional vaults, which also attempts to upload metadata for conditional tokens. If a previous attempt to call this script failed part way through and off-chain metadata has already been uploaded, you can use this metadata and bypass another attempt to upload off-chain metadata.
+
+Simply prepend the script with the following environment variable structure: `[PASS|FAIL]_[TOKEN]_METADATA_URI`. For example, to override pass and fail META metadata uploads, include `PASS_META_METADATA_URI` and `FAIL_META_METADATA_URI`.
+
+The actual script invocation might look something like this:
+
+```bash
+PASS_META_METADATA_URI=\"<P_URI>\" FAIL_META_METADATA_URI=\"<F_URI>\" anchor run propose
+```
+
+where `P_URI` and `F_URI` are replaced with their respective values.
+
 ## Deployments
 
 | program           | tag  | program ID                                  |

--- a/scripts/uploadOffchainMetadata.ts
+++ b/scripts/uploadOffchainMetadata.ts
@@ -124,59 +124,115 @@ export const uploadImageJson = async (
   const market = conditionalToken.toLowerCase().startsWith("p")
     ? "pass"
     : "fail";
-  return umi.uploader.uploadJson({
-    name: `Proposal ${proposal.toNumber()}: ${conditionalToken}`,
-    image,
-    symbol: conditionalToken,
-    description: `Native token in the MetaDAO's conditional ${market} market for proposal ${proposal.toNumber()}`,
-  });
+  return umi.uploader.uploadJson(
+    {
+      name: `Proposal ${proposal.toNumber()}: ${conditionalToken}`,
+      image,
+      symbol: conditionalToken,
+      description: `Native token in the MetaDAO's conditional ${market} market for proposal ${proposal.toNumber()}`,
+    },
+    {
+      onProgress: (percent: number, ...args: any) => {
+        console.log(
+          `percent metadata upload progress for ${conditionalToken} = ${percent}`
+        );
+        console.log("progress args: ", args);
+      },
+    }
+  );
 };
 
 export const uploadOffchainMetadata = async (
   proposal: anchor.BN,
   symbol: string
-) => {
+):
+  | Promise<{
+      symbol: string;
+      passTokenMetadataUri: string | undefined;
+      failTokenMetadataUri: string | undefined;
+    }>
+  | undefined => {
+  const isOverrideDefined = (value: string) =>
+    value && value.trim().length > 0 && value.includes("https://");
+
+  const getValueOrUndefined = <T>(
+    result: PromiseSettledResult<T>,
+    action?: string
+  ): T | undefined => {
+    if (result.status === "rejected") {
+      console.error(
+        `${action ? `[${action}] ` : "request failed: "}`,
+        result.reason
+      );
+      return undefined;
+    }
+
+    return result.value;
+  };
+
   // use bundlr, targeting arweave
   umi.use(bundlrUploader());
 
   if (!isAcceptedVaultToken(symbol)) {
-    throw new Error(`Unrecognized symbol provided: ${symbol}`);
+    console.warn(
+      `unrecognized symbol provided. Skipping upload since we do not have conditional images for token: ${symbol}...`
+    );
+    return undefined;
   }
 
-  console.log(`uploading metadata for token ${symbol}...`);
-  const [passUri, failUri] = await Promise.all(
-    [`p${symbol}`, `f${symbol}`].map((symbol) => {
+  console.log(`uploading metadata for conditional ${symbol} tokens...`);
+  const [passUploadResult, failUploadResult] = await Promise.allSettled(
+    [
+      {
+        symbol: `p${symbol}`,
+        override: process.env[`PASS_${symbol}_METADATA_URI`],
+      },
+      {
+        symbol: `f${symbol}`,
+        override: process.env[`FAIL_${symbol}_METADATA_URI`],
+      },
+    ].map((o) => {
+      if (isOverrideDefined(o.override)) return o.override.trim();
       return uploadImageJson(
         proposal,
-        symbol as ConditionalToken,
-        uploadedAssetMap[symbol]
+        o.symbol as ConditionalToken,
+        uploadedAssetMap[o.symbol]
       );
     })
   );
 
   return {
     symbol,
-    passTokenMetadataUri: passUri,
-    faileTokenMetadataUri: failUri,
+    passTokenMetadataUri: getValueOrUndefined(
+      passUploadResult,
+      "upload pass token metadata"
+    ),
+    failTokenMetadataUri: getValueOrUndefined(
+      failUploadResult,
+      "upload fail token metadata"
+    ),
   };
 };
 
+/**
+ * todo: when we support other metadata implementations (e.g. metaplex, token22),
+ * this method needs to check for those implementations
+ */
 export const fetchOnchainMetadataForMint = async (
   address: PublicKey
-):
-  | Promise<{
+): Promise<
+  | {
       key: PublicKey;
       metadata: Metadata;
-    }>
-  | undefined => {
+    }
+  | undefined
+> => {
   const pda = findMetadataPda(umi, {
     mint: fromWeb3JsPublicKey(address),
   });
 
   const acct = await umi.rpc.getAccount(pda[0]);
-  if (!acct.exists) {
-    throw new Error(`Unable to find metaplex metdata for mint = ${address}`);
-  }
+  if (!acct.exists) return undefined;
 
   return {
     key: toWeb3JsPublicKey(pda[0]),


### PR DESCRIPTION
## Description of changes

1. Make the off-chain conditional token metadata uploads script logic more flexible. Notably, we will skip attempting to upload off-chain metadata (and skip adding on-chain metadata) for tokens that
   - do not have associated metaplex metadata, or
   - use a symbol that is not USDC or META (because we do not have pre-configured pass/fail images for them)
2. Since the initialize proposal script can easily fail if any transaction fails, I added the option to bypass metadata uploads if we already have a value with which we are happy. The caller simply has to include some environment variables to override the values:
   - e.g. for the META conditional mints, including values for `PASS_META_METADATA_URI` and `FAIL_META_METADATA_URI` will skip uploading off-chain metadata for both. It's also possible to include pass and not fail, and vice versa.
3. I also removed a pesky import that I _thought_ I previously removed: https://github.com/metaDAOproject/futarchy/blob/6fe4a119c46ab7800c0fcd8b11875fcdcd7c9636/scripts/main.ts#L3

### Note

- I decided to use the Metaplex umi interface for metadata related things because it makes fetching that data pretty nice. However, one issue that arises is the code to upload assets to Arweave is a little bit abstracted away, so I didn't yet figure out how to (1) retry failed transactions or (2) add a priority fee to those transactions. But, this shouldn't be a blocker because if the caller has to retry initialize proposal, they can directly inject asset endpoints as environment variables (as mentioned above)

## Testing

- Verified that all tests still pass when calling `anchor tests`
- Created a temporary script that explicitly tested the `initializeVault`, which is a function called during the `initializeProposal` script with mainnet (META) and devnet (USDC)

The script would have previously failed with a token like devnet USDC that includes metadata but is not a symbol we [support with pre-made conditional mint images](https://github.com/metaDAOproject/futarchy/tree/develop/scripts/assets), but it should now succeed with the log output that includes the following:

```bash
unrecognized symbol provided. Skipping upload since we do not have conditional images for token: TOKE...
skipping add metadata instruction for initialize vault transaction...
```