### PR TITLE
Improve constraints

### DIFF
--- a/programs/autocrat_v0/src/lib.rs
+++ b/programs/autocrat_v0/src/lib.rs
@@ -223,7 +223,7 @@ pub mod autocrat_v0 {
             let oracle = &twap_market.twap_oracle;
 
             require!(
-                oracle.initial_slot + 50 >= clock.slot,
+                clock.slot <= oracle.initial_slot + 50,
                 AutocratError::TWAPMarketTooOld
             );
 

--- a/programs/autocrat_v0/src/lib.rs
+++ b/programs/autocrat_v0/src/lib.rs
@@ -157,26 +157,22 @@ pub mod autocrat_v0 {
         let clock = Clock::get()?;
 
         require!(
-            pass_market.base_mint
-                == ctx.accounts.base_vault.conditional_on_finalize_token_mint,
+            pass_market.base_mint == ctx.accounts.base_vault.conditional_on_finalize_token_mint,
             AutocratError::InvalidMarket
         );
         require!(
-            pass_market.quote_mint
-                == ctx.accounts.quote_vault.conditional_on_finalize_token_mint,
+            pass_market.quote_mint == ctx.accounts.quote_vault.conditional_on_finalize_token_mint,
             AutocratError::InvalidMarket
         );
         require!(
-            fail_market.base_mint
-                == ctx.accounts.base_vault.conditional_on_revert_token_mint,
+            fail_market.base_mint == ctx.accounts.base_vault.conditional_on_revert_token_mint,
             AutocratError::InvalidMarket
         );
         require!(
-            fail_market.quote_mint
-                == ctx.accounts.quote_vault.conditional_on_revert_token_mint,
+            fail_market.quote_mint == ctx.accounts.quote_vault.conditional_on_revert_token_mint,
             AutocratError::InvalidMarket
         );
-        
+
         for market in [&pass_market, &fail_market] {
             // The market expires a minimum of 7 days after the end of a 3 day proposal.
             // Make sure to do final TWAP crank after the proposal period has ended
@@ -186,20 +182,14 @@ pub mod autocrat_v0 {
                 AutocratError::InvalidMarket
             );
 
-            require!(
-                market.seq_num == 0,
-                AutocratError::InvalidMarket
-            );
+            require!(market.seq_num == 0, AutocratError::InvalidMarket);
 
             require!(
                 market.taker_fee == dao.market_taker_fee,
                 AutocratError::InvalidMarket
             );
 
-            require!(
-                market.maker_fee == 0,
-                AutocratError::InvalidMarket
-            );
+            require!(market.maker_fee == 0, AutocratError::InvalidMarket);
 
             require!(
                 market.base_lot_size == dao.base_lot_size,
@@ -210,7 +200,7 @@ pub mod autocrat_v0 {
                 market.quote_lot_size == 100, // you can quote in increments of a hundredth of a penny
                 AutocratError::InvalidMarket
             );
-            
+
             require!(
                 pass_market.collect_fee_admin == dao.treasury,
                 AutocratError::InvalidMarket
@@ -386,11 +376,7 @@ pub mod autocrat_v0 {
             }
         }
 
-        solana_program::program::invoke_signed(
-            &svm_instruction,
-            ctx.remaining_accounts,
-            signer,
-        )?;
+        solana_program::program::invoke_signed(&svm_instruction, ctx.remaining_accounts, signer)?;
 
         Ok(())
     }

--- a/programs/autocrat_v0/src/lib.rs
+++ b/programs/autocrat_v0/src/lib.rs
@@ -159,20 +159,24 @@ pub mod autocrat_v0 {
         let dao = &mut ctx.accounts.dao;
         let clock = Clock::get()?;
 
-        require!(
-            pass_market.base_mint == base_vault.conditional_on_finalize_token_mint,
+        require_eq!(
+            pass_market.base_mint,
+            base_vault.conditional_on_finalize_token_mint,
             AutocratError::InvalidMarket
         );
-        require!(
-            pass_market.quote_mint == quote_vault.conditional_on_finalize_token_mint,
+        require_eq!(
+            pass_market.quote_mint,
+            quote_vault.conditional_on_finalize_token_mint,
             AutocratError::InvalidMarket
         );
-        require!(
-            fail_market.base_mint == base_vault.conditional_on_revert_token_mint,
+        require_eq!(
+            fail_market.base_mint,
+            base_vault.conditional_on_revert_token_mint,
             AutocratError::InvalidMarket
         );
-        require!(
-            fail_market.quote_mint == quote_vault.conditional_on_revert_token_mint,
+        require_eq!(
+            fail_market.quote_mint,
+            quote_vault.conditional_on_revert_token_mint,
             AutocratError::InvalidMarket
         );
 
@@ -185,25 +189,26 @@ pub mod autocrat_v0 {
                 AutocratError::InvalidMarket
             );
 
-            require!(
-                market.taker_fee == dao.market_taker_fee,
+            require_eq!(
+                market.taker_fee,
+                dao.market_taker_fee,
                 AutocratError::InvalidMarket
             );
 
-            require!(market.maker_fee == 0, AutocratError::InvalidMarket);
+            require_eq!(market.maker_fee, 0, AutocratError::InvalidMarket);
 
-            require!(
-                market.base_lot_size == dao.base_lot_size,
+            require_eq!(
+                market.base_lot_size, dao.base_lot_size,
                 AutocratError::InvalidMarket
             );
 
-            require!(
-                market.quote_lot_size == 100, // you can quote in increments of a hundredth of a penny
+            require_eq!(
+                market.quote_lot_size, 100, // you can quote in increments of a hundredth of a penny
                 AutocratError::InvalidMarket
             );
 
-            require!(
-                market.collect_fee_admin == dao.treasury,
+            require_eq!(
+                market.collect_fee_admin, dao.treasury,
                 AutocratError::InvalidMarket
             );
         }
@@ -225,8 +230,8 @@ pub mod autocrat_v0 {
                 AutocratError::TWAPOracleWrongChangeLots
             );
 
-            require!(
-                twap_market.twap_oracle.expected_value == dao.twap_expected_value,
+            require_eq!(
+                twap_market.twap_oracle.expected_value, dao.twap_expected_value,
                 AutocratError::TWAPMarketInvalidExpectedValue
             );
         }
@@ -273,12 +278,14 @@ pub mod autocrat_v0 {
 
         // least signficant 32 bits of nonce are proposal number
         // most significant bit of nonce is 0 for base (META) and 1 for quote (USDC)
-        require!(
-            base_vault.nonce == proposal.number as u64,
+        require_eq!(
+            base_vault.nonce,
+            proposal.number as u64,
             AutocratError::InvalidVaultNonce
         );
-        require!(
-            quote_vault.nonce == (proposal.number as u64 | (1 << 63)),
+        require_eq!(
+            quote_vault.nonce,
+            (proposal.number as u64 | (1 << 63)),
             AutocratError::InvalidVaultNonce
         );
 

--- a/programs/autocrat_v0/src/lib.rs
+++ b/programs/autocrat_v0/src/lib.rs
@@ -203,7 +203,7 @@ pub mod autocrat_v0 {
             );
 
             require!(
-                pass_market.collect_fee_admin == dao.treasury,
+                market.collect_fee_admin == dao.treasury,
                 AutocratError::InvalidMarket
             );
         }

--- a/programs/autocrat_v0/src/lib.rs
+++ b/programs/autocrat_v0/src/lib.rs
@@ -198,17 +198,20 @@ pub mod autocrat_v0 {
             require_eq!(market.maker_fee, 0, AutocratError::InvalidMarket);
 
             require_eq!(
-                market.base_lot_size, dao.base_lot_size,
+                market.base_lot_size,
+                dao.base_lot_size,
                 AutocratError::InvalidMarket
             );
 
             require_eq!(
-                market.quote_lot_size, 100, // you can quote in increments of a hundredth of a penny
+                market.quote_lot_size,
+                100, // you can quote in increments of a hundredth of a penny
                 AutocratError::InvalidMarket
             );
 
             require_eq!(
-                market.collect_fee_admin, dao.treasury,
+                market.collect_fee_admin,
+                dao.treasury,
                 AutocratError::InvalidMarket
             );
         }
@@ -217,21 +220,22 @@ pub mod autocrat_v0 {
         let fail_twap_market = &ctx.accounts.openbook_twap_fail_market;
 
         for twap_market in [pass_twap_market, fail_twap_market] {
+            let oracle = &twap_market.twap_oracle;
+
             require!(
-                twap_market.twap_oracle.initial_slot + 50 >= clock.slot,
+                oracle.initial_slot + 50 >= clock.slot,
                 AutocratError::TWAPMarketTooOld
             );
 
             require_eq!(
-                twap_market
-                    .twap_oracle
-                    .max_observation_change_per_update_lots,
+                oracle.max_observation_change_per_update_lots,
                 dao.max_observation_change_per_update_lots,
                 AutocratError::TWAPOracleWrongChangeLots
             );
 
             require_eq!(
-                twap_market.twap_oracle.expected_value, dao.twap_expected_value,
+                oracle.expected_value,
+                dao.twap_expected_value,
                 AutocratError::TWAPMarketInvalidExpectedValue
             );
         }
@@ -335,9 +339,8 @@ pub mod autocrat_v0 {
         let fail_market_twap = calculate_twap(&fail_twap_market)?;
         let pass_market_twap = calculate_twap(&pass_twap_market)?;
 
-        let threshold = (fail_market_twap
-            * (MAX_BPS + dao.pass_threshold_bps) as u128)
-            / MAX_BPS as u128;
+        let threshold =
+            (fail_market_twap * (MAX_BPS + dao.pass_threshold_bps) as u128) / MAX_BPS as u128;
 
         let (new_proposal_state, new_vault_state) = if pass_market_twap > threshold {
             (ProposalState::Passed, VaultStatus::Finalized)

--- a/programs/autocrat_v0/src/lib.rs
+++ b/programs/autocrat_v0/src/lib.rs
@@ -182,8 +182,6 @@ pub mod autocrat_v0 {
                 AutocratError::InvalidMarket
             );
 
-            require!(market.seq_num == 0, AutocratError::InvalidMarket);
-
             require!(
                 market.taker_fee == dao.market_taker_fee,
                 AutocratError::InvalidMarket


### PR DESCRIPTION
Recently, a serious bug was found in the v0.1 version of autocrat that was missed because repeated constraints & verbose naming. Here we slim down the names and abstract away the constraints.