### PR TITLE
Update Cargo.toml version number

### DIFF
--- a/programs/autocrat_v0/Cargo.toml
+++ b/programs/autocrat_v0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autocrat_v0"
-version = "0.1.0"
+version = "0.3.0"
 description = "Created with Anchor"
 edition = "2021"
 


### PR DESCRIPTION
I am told that `develop` is on autocrat version 0.3.0, so the Cargo.toml should reflect this