### PR TITLE
fix(scripts): Update `mintConditionalTokens` to Handle Fractional Units

### DIFF
--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -791,7 +791,7 @@ export async function mintConditionalTokens(amount: number, vault: PublicKey) {
     .rpc();
 }
 
-async function getTokenDecimals(mint: PublicKey): Promise<number> {
+export async function getTokenDecimals(mint: PublicKey): Promise<number> {
   try {
     const mintInfo = await token.getMint(provider.connection, mint);
     return mintInfo.decimals;

--- a/sdk/src/ConditionalVaultClient.ts
+++ b/sdk/src/ConditionalVaultClient.ts
@@ -24,8 +24,6 @@ import {
   getAssociatedTokenAddressSync,
 } from "@solana/spl-token";
 
-import { getTokenDecimals } from "../../scripts/main";
-
 export type CreateVaultClientParams = {
   provider: AnchorProvider;
   conditionalVaultProgramId?: PublicKey;
@@ -76,8 +74,7 @@ export class ConditionalVaultClient {
     const storedVault = await this.getVault(vault);
 
     try {
-      const tokenDecimals = await getTokenDecimals(storedVault.underlyingTokenMint);
-      const scaledAmount = uiAmount * Math.pow(10, tokenDecimals);
+      const scaledAmount = uiAmount * Math.pow(10, storedVault.decimals);
       const bnAmount = new BN(scaledAmount.toFixed(0));
 
       return this.mintConditionalTokensIx(


### PR DESCRIPTION
This PR aims to resolve #245 by:
- Converting the user-provided `input` to the smallest unit of the token based on its decimals
- Calculate the scaled amount by multiplying the input amount by 10^(token's decimals)
- Round the scaled amount to the nearest integer
- Create a new `BN` with the scaled, rounded amount

This PR also adds the `getTokenDecimals` helper function to streamline fetching a token's decimals