### PR TITLE
Update launchpad events for simpler historic indexing

### DIFF
--- a/programs/launchpad/src/events.rs
+++ b/programs/launchpad/src/events.rs
@@ -22,10 +22,16 @@ impl CommonFields {
 pub struct LaunchInitializedEvent {
     pub common: CommonFields,
     pub launch: Pubkey,
-    pub token_mint: Pubkey,
+    pub minimum_raise_amount: u64,
     pub creator: Pubkey,
+    pub launch_signer: Pubkey,
+    pub launch_signer_pda_bump: u8,
+    pub launch_usdc_vault: Pubkey,
+    pub launch_token_vault: Pubkey,
+    pub token_mint: Pubkey,
     pub usdc_mint: Pubkey,
     pub pda_bump: u8,
+    pub slots_for_launch: u64,
 }
 
 #[event]

--- a/programs/launchpad/src/instructions/initialize_launch.rs
+++ b/programs/launchpad/src/instructions/initialize_launch.rs
@@ -116,10 +116,16 @@ impl InitializeLaunch<'_> {
         emit_cpi!(LaunchInitializedEvent {
             common: CommonFields::new(&clock, 0),
             launch: ctx.accounts.launch.key(),
+            minimum_raise_amount: args.minimum_raise_amount,
             creator: ctx.accounts.creator.key(),
-            usdc_mint: ctx.accounts.usdc_mint.key(),
+            launch_signer: ctx.accounts.launch_signer.key(),
+            launch_signer_pda_bump: ctx.bumps.launch_signer,
+            launch_usdc_vault: ctx.accounts.usdc_vault.key(),
+            launch_token_vault: ctx.accounts.token_vault.key(),
             token_mint: ctx.accounts.token_mint.key(),
+            usdc_mint: ctx.accounts.usdc_mint.key(),
             pda_bump: ctx.bumps.launch,
+            slots_for_launch: args.slots_for_launch,
         });
 
         let launch_key = ctx.accounts.launch.key();

--- a/sdk/src/v0.4/types/index.ts
+++ b/sdk/src/v0.4/types/index.ts
@@ -72,3 +72,22 @@ export type ConditionalVaultEvent =
   | RedeemTokensEvent
   | ResolveQuestionEvent
   | SplitTokensEvent;
+
+export type LaunchClaimEvent = IdlEvents<LaunchpadProgram>["LaunchClaimEvent"];
+export type LaunchCompletedEvent =
+  IdlEvents<LaunchpadProgram>["LaunchCompletedEvent"];
+export type LaunchFundedEvent =
+  IdlEvents<LaunchpadProgram>["LaunchFundedEvent"];
+export type LaunchInitializedEvent =
+  IdlEvents<LaunchpadProgram>["LaunchInitializedEvent"];
+export type LaunchRefundedEvent =
+  IdlEvents<LaunchpadProgram>["LaunchRefundedEvent"];
+export type LaunchStartedEvent =
+  IdlEvents<LaunchpadProgram>["LaunchStartedEvent"];
+export type LaunchpadEvent =
+  | LaunchClaimEvent
+  | LaunchCompletedEvent
+  | LaunchFundedEvent
+  | LaunchInitializedEvent
+  | LaunchRefundedEvent
+  | LaunchStartedEvent;

--- a/sdk/src/v0.4/types/launchpad.ts
+++ b/sdk/src/v0.4/types/launchpad.ts
@@ -681,12 +681,37 @@ export type Launchpad = {
           index: false;
         },
         {
-          name: "tokenMint";
-          type: "publicKey";
+          name: "minimumRaiseAmount";
+          type: "u64";
           index: false;
         },
         {
           name: "creator";
+          type: "publicKey";
+          index: false;
+        },
+        {
+          name: "launchSigner";
+          type: "publicKey";
+          index: false;
+        },
+        {
+          name: "launchSignerPdaBump";
+          type: "u8";
+          index: false;
+        },
+        {
+          name: "launchUsdcVault";
+          type: "publicKey";
+          index: false;
+        },
+        {
+          name: "launchTokenVault";
+          type: "publicKey";
+          index: false;
+        },
+        {
+          name: "tokenMint";
           type: "publicKey";
           index: false;
         },
@@ -698,6 +723,11 @@ export type Launchpad = {
         {
           name: "pdaBump";
           type: "u8";
+          index: false;
+        },
+        {
+          name: "slotsForLaunch";
+          type: "u64";
           index: false;
         }
       ];
@@ -1597,12 +1627,37 @@ export const IDL: Launchpad = {
           index: false,
         },
         {
-          name: "tokenMint",
-          type: "publicKey",
+          name: "minimumRaiseAmount",
+          type: "u64",
           index: false,
         },
         {
           name: "creator",
+          type: "publicKey",
+          index: false,
+        },
+        {
+          name: "launchSigner",
+          type: "publicKey",
+          index: false,
+        },
+        {
+          name: "launchSignerPdaBump",
+          type: "u8",
+          index: false,
+        },
+        {
+          name: "launchUsdcVault",
+          type: "publicKey",
+          index: false,
+        },
+        {
+          name: "launchTokenVault",
+          type: "publicKey",
+          index: false,
+        },
+        {
+          name: "tokenMint",
           type: "publicKey",
           index: false,
         },
@@ -1614,6 +1669,11 @@ export const IDL: Launchpad = {
         {
           name: "pdaBump",
           type: "u8",
+          index: false,
+        },
+        {
+          name: "slotsForLaunch",
+          type: "u64",
           index: false,
         },
       ],


### PR DESCRIPTION
This PR adds relevant fields to the `LaunchInitializedEvent` in order to easily track it from the historic indexer.

Related PR with more context: https://github.com/metaDAOproject/futarchy-indexer/pull/344