### PR TITLE
Hotfix AMM swap user to use the user as the payer, bump package version

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metadaoproject/futarchy",
-  "version": "0.4.0-alpha.55",
+  "version": "0.4.0-alpha.56",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/sdk/src/v0.4/AmmClient.ts
+++ b/sdk/src/v0.4/AmmClient.ts
@@ -353,7 +353,7 @@ export class AmmClient {
       .preInstructions([
         // create the receiving token account if it doesn't exist
         createAssociatedTokenAccountIdempotentInstruction(
-          this.provider.publicKey,
+          user,
           getAssociatedTokenAddressSync(receivingToken, user),
           user,
           receivingToken


### PR DESCRIPTION
This caused an issue in this PR: https://github.com/metaDAOproject/metadao-frontend-v2/pull/296

The issue was an `undefined.toString()` during transaction serialization. Somehow, Anchor's `provider.wallet` ended up being `undefined` when you initialize `AmmClient` with the browser's `provider`.