### PR TITLE
Feat: add duration_in_slots to Proposal, copying it over from Dao

### DIFF
--- a/programs/autocrat/src/events.rs
+++ b/programs/autocrat/src/events.rs
@@ -63,6 +63,7 @@ pub struct InitializeProposalEvent {
     pub fail_lp_tokens_locked: u64,
     pub pda_bump: u8,
     pub instruction: ProposalInstruction,
+    pub duration_in_slots: u64,
 }
 
 #[event]

--- a/programs/autocrat/src/instructions/finalize_proposal.rs
+++ b/programs/autocrat/src/instructions/finalize_proposal.rs
@@ -134,7 +134,7 @@ impl FinalizeProposal<'_> {
             let slots_passed = amm.oracle.last_updated_slot - proposal.slot_enqueued;
 
             require!(
-                slots_passed >= dao.slots_per_proposal,
+                slots_passed >= proposal.duration_in_slots,
                 AutocratError::MarketsTooYoung
             );
 

--- a/programs/autocrat/src/instructions/initialize_proposal.rs
+++ b/programs/autocrat/src/instructions/initialize_proposal.rs
@@ -228,6 +228,7 @@ impl InitializeProposal<'_> {
             nonce,
             pda_bump: ctx.bumps.proposal,
             question: question.key(),
+            duration_in_slots: dao.slots_per_proposal,
         });
 
         emit_cpi!(InitializeProposalEvent {
@@ -248,6 +249,7 @@ impl InitializeProposal<'_> {
             fail_lp_tokens_locked: fail_lp_tokens_to_lock,
             pda_bump: ctx.bumps.proposal,
             instruction,
+            duration_in_slots: proposal.duration_in_slots,
         });
 
         Ok(())

--- a/programs/autocrat/src/state/proposal.rs
+++ b/programs/autocrat/src/state/proposal.rs
@@ -44,6 +44,7 @@ pub struct Proposal {
     pub nonce: u64,
     pub pda_bump: u8,
     pub question: Pubkey,
+    pub duration_in_slots: u64,
 }
 
 impl From<&ProposalInstruction> for Instruction {


### PR DESCRIPTION
This prevents the following situation:

1. Proposal A to reduce `slots_per_proposal` is created
2. Proposal B (arbitrary) is created
3. Proposal A passes and gets executed
4. Proposal B gets forcibly executed, before its originally intended end slot