### PR TITLE
deploy IDL and program through Squads multisig

### DIFF
--- a/.github/workflows/anchor-test.yaml
+++ b/.github/workflows/anchor-test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-anchor-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: metadaoproject/anchor-test@v2.1

--- a/.github/workflows/deploy-buffer.yaml
+++ b/.github/workflows/deploy-buffer.yaml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   deploy-buffer:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: metadaoproject/setup-anchor@v3

--- a/.github/workflows/deploy-buffer.yaml
+++ b/.github/workflows/deploy-buffer.yaml
@@ -30,6 +30,11 @@ on:
         type: string
         description: "Index of the multisig vault executing the upgrade"
         default: "0"
+      multisig-vault-address:
+        required: true
+        type: string
+        description: "Address of the multisig vault executing the upgrade"
+        default: "ALxsUozu7d8ibng4k3aF9CPj1VGPGt8ZRogbpUwYsZkq"
       spill_address:
         required: true
         type: string
@@ -103,11 +108,12 @@ jobs:
           AUTHORITY: ${{ inputs.buffer-authority }}
           NETWORK: ${{ inputs.network }}
       - name: Set upgrade authority to Squads multisig
-        uses: metaDAOproject/squads-v4-program-upgrade@0.0.3
+        uses: metaDAOproject/squads-v4-program-upgrade@1.0.0
         with:
           network-url: ${{ inputs.rpc_url }}
           multisig-pda: ${{ inputs.multisig_pda }}
           multisig-vault-index: ${{ inputs.multisig_vault_index }}
+          multisig-vault-address: ${{ inputs.multisig_vault_address }}
           program-id: ${{ inputs.program_id }}
           buffer: "${{ steps.buffer-deploy-store.outputs.BUFFER }}"
           spill-address: ${{ inputs.spill_address }}

--- a/.github/workflows/deploy-buffer.yaml
+++ b/.github/workflows/deploy-buffer.yaml
@@ -103,7 +103,7 @@ jobs:
           AUTHORITY: ${{ inputs.buffer-authority }}
           NETWORK: ${{ inputs.network }}
       - name: Set upgrade authority to Squads multisig
-        uses: pileks/squads-v4-program-upgrade@0.0.3
+        uses: metaDAOproject/squads-v4-program-upgrade@0.0.3
         with:
           network-url: ${{ inputs.rpc_url }}
           multisig-pda: ${{ inputs.multisig_pda }}

--- a/.github/workflows/deploy-buffer.yaml
+++ b/.github/workflows/deploy-buffer.yaml
@@ -15,6 +15,26 @@ on:
         description: 'RPC URL'
         required: true
         type: string
+      program_executable_data:
+        required: true
+        type: string
+        description: "The program executable data address"
+        default: "H5rxQS4BGc77552Da6aDDNH2G7HCpC1fUxyeuDpwEQK4"
+      multisig_pda:
+        required: true
+        type: string
+        description: "The multisig pda to set as buffer authority"
+        default: "J5wHJwmkyhx1rnn7xeYyUVKYgCvDPwGJz4h44WE6cHCJ"
+      multisig_vault_index:
+        required: true
+        type: string
+        description: "Index of the multisig vault executing the upgrade"
+        default: "0"
+      spill_address:
+        required: true
+        type: string
+        description: "Spill address to recoup funds from buffers"
+        default: "2SG7fCnreQ9wHoqQC7U6pfDN2rYmBqExKuqcGR3StrZW"
 
 
 jobs:
@@ -38,4 +58,60 @@ jobs:
           timeout_minutes: 30
           max_attempts: 10
           shell: bash
-          command: solana program write-buffer --max-sign-attempts 50 --with-compute-unit-price 100 --use-rpc --buffer ./buffer-keypair ./verifiable-builds/${{ inputs.program_name }}.so -u $NETWORK
+          command: solana program write-buffer --max-sign-attempts 50 --with-compute-unit-price 100 --use-rpc --buffer ./buffer-keypair ./verifiable-builds/${{ inputs.program_name }}.so -u ${{ inputs.rpc_url }} > ./buffer.out
+      - name: IDL Buffer Deploy
+        uses: nick-invision/retry@v2
+        id: idl-buffer-deploy
+        with:
+          timeout_minutes: 30
+          max_attempts: 10
+          shell: bash
+          command: anchor idl write-buffer ${{ inputs.program_id }} --filepath ./verifiable-builds/${{ inputs.program_name }}.json --provider.cluster ${{ inputs.rpc_url }} --provider.wallet ./deploy-keypair.json > idl-buffer.out
+      - name: Buffer Deploy Store
+        shell: bash
+        id: buffer-deploy-store
+        run: |
+          echo "BUFFER=$(cat buffer.out | sed 's/Buffer: //g' | xargs echo -n)" >> $GITHUB_OUTPUT
+          echo "IDL_BUFFER=$(cat idl-buffer.out | grep -oE '[1-9A-HJ-NP-Za-km-z]{32,44}$' | xargs echo -n)" >> $GITHUB_OUTPUT
+      - run: echo "The buffer is ${{ steps.buffer-deploy-store.outputs.BUFFER }}"
+        shell: bash
+      - run: echo "the idl buffer is ${{ steps.buffer-deploy-store.outputs.IDL_BUFFER }}"
+        shell: bash
+      - name: Transfer idl buffer to authority
+        uses: nick-invision/retry@v2
+        if: steps.cache-buffer.outputs.cache-hit != 'true'
+        with:
+          timeout_minutes: 10
+          max_attempts: 20
+          shell: bash
+          command: anchor idl set-authority $IDL_BUFFER --provider.cluster $NETWORK --program-id $PROGRAM_ID --new-authority $AUTHORITY --provider.wallet ./deploy-keypair.json
+        env:
+          IDL_BUFFER: ${{ steps.buffer-deploy-store.outputs.IDL_BUFFER }}
+          AUTHORITY: ${{ inputs.buffer-authority }}
+          NETWORK: ${{ inputs.network }}
+          PROGRAM_ID: ${{ inputs.program-id }}
+      - name: Transfer program buffer to authority
+        uses: nick-invision/retry@v2
+        if: steps.cache-buffer.outputs.cache-hit != 'true'
+        with:
+          timeout_minutes: 10
+          max_attempts: 20
+          shell: bash
+          command: solana program set-buffer-authority $BUFFER -k ./deploy-keypair.json --new-buffer-authority $AUTHORITY -u $NETWORK
+        env:
+          BUFFER: ${{ steps.buffer-deploy-store.outputs.BUFFER }}
+          AUTHORITY: ${{ inputs.buffer-authority }}
+          NETWORK: ${{ inputs.network }}
+      - name: Set upgrade authority to Squads multisig
+        uses: pileks/squads-v4-program-upgrade@0.0.3
+        with:
+          network-url: ${{ inputs.rpc_url }}
+          multisig-pda: ${{ inputs.multisig_pda }}
+          multisig-vault-index: ${{ inputs.multisig_vault_index }}
+          program-id: ${{ inputs.program_id }}
+          buffer: "${{ steps.buffer-deploy-store.outputs.BUFFER }}"
+          spill-address: ${{ inputs.spill_address }}
+          name: "Test Upgrade"
+          executable-data: ${{ inputs.program_executable_data }}
+          keypair: ${{ secrets.DEPLOYER_KEYPAIR }}
+          idl-buffer: "${{ steps.buffer-deploy-store.outputs.IDL_BUFFER }}"

--- a/.github/workflows/generate-verifiable-builds.yaml
+++ b/.github/workflows/generate-verifiable-builds.yaml
@@ -18,6 +18,7 @@ jobs:
           solana-cli-version: '1.17.16'
       - run: 'git pull --rebase'
       - run: cp target/deploy/autocrat.so ./verifiable-builds
+      - run: cp target/idl/autocrat.json ./verifiable-builds
       - name: Commit verifiable build back to mainline
         uses: EndBug/add-and-commit@v9.1.4
         with:
@@ -35,6 +36,7 @@ jobs:
           features: 'production'
       - run: 'git pull --rebase'
       - run: cp target/deploy/conditional_vault.so ./verifiable-builds
+      - run: cp target/idl/conditional_vault.json ./verifiable-builds
       - name: Commit verifiable build back to mainline
         uses: EndBug/add-and-commit@v9.1.4
         with:
@@ -51,6 +53,7 @@ jobs:
           solana-cli-version: '1.17.16'
       - run: 'git pull --rebase'
       - run: cp target/deploy/amm.so ./verifiable-builds
+      - run: cp target/idl/amm.json ./verifiable-builds
       - name: Commit verifiable build back to mainline
         uses: EndBug/add-and-commit@v9.1.4
         with:
@@ -68,6 +71,7 @@ jobs:
           features: 'production'
       - run: 'git pull --rebase'
       - run: cp target/deploy/launchpad.so ./verifiable-builds
+      - run: cp target/idl/launchpad.json ./verifiable-builds
       - name: Commit verifiable build back to mainline
         uses: EndBug/add-and-commit@v9.1.4
         with:

--- a/.github/workflows/generate-verifiable-builds.yaml
+++ b/.github/workflows/generate-verifiable-builds.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   generate-verifiable-autocrat:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: metadaoproject/anchor-verifiable-build@v0.2
@@ -25,7 +25,7 @@ jobs:
           default_author: github_actions
           message: 'Update autocrat verifiable build'
   generate-verifiable-vault:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: metadaoproject/anchor-verifiable-build@v0.2
@@ -43,7 +43,7 @@ jobs:
           default_author: github_actions
           message: 'Update conditional_vault verifiable build'
   generate-verifiable-amm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: metadaoproject/anchor-verifiable-build@v0.2
@@ -60,7 +60,7 @@ jobs:
           default_author: github_actions
           message: 'Update amm verifiable build'
   generate-verifiable-launchpad:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: metadaoproject/anchor-verifiable-build@v0.2

--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   verify-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: metadaoproject/setup-anchor@v2


### PR DESCRIPTION
This PR **should** (need to test for this repo in particular) introduce deploying programs through a Squads multisig.

It assumes that the previous workflows work, which should be the case as I've taken a look at the previous runs.

Prerequisites:
- [ ] Squads multisig PDA set up, together with vault.
  - [ ] The multisig PDA and the vault index (`0` for the first vault) are inputs into the workflow dispatch, need to set them as such.
- [ ] The deployer keypair needs to be part of the squads multisig
  - They are the ones proposing the multisig transaction which sets the program/idl buffers
- [ ] Ideally, you can set the deployer keypair as the `spill_address` as well
- [ ] Set the workflow defaults to values that work for MetaDAO

We can later think of optimizing this flow, but the basics are now here and they should work nicely.
I have a bit of a different example (2-job workflow) set up in [my example repo](https://github.com/pileks/squads-idl-deploy-example), we can take inspiration from there as well.