### PR TITLE
quality of life fixes for Mac devs

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,4 +1,5 @@
 [toolchain]
+solana_version = "1.17.34"
 
 [features]
 seeds = false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.78.0"

--- a/test.sh
+++ b/test.sh
@@ -102,7 +102,13 @@ if [ "$WATCH" = true ]; then
     echo "Watching for changes in: $WATCH_PATHS"
     echo "Command: $FINAL_CMD"
     echo ""
-    find $WATCH_PATHS | entr -sc "$FINAL_CMD"
+    find $WATCH_PATHS -type f \
+        -not -path "*/node_modules/*" \
+        -not -path "*/target/*" \
+        -not -path "*/.anchor/*" \
+        -not -path "*/dist/*" \
+        -not -path "*/.git/*" \
+        | entr -sc "$FINAL_CMD"
 else
     echo "Running command: $FINAL_CMD"
     echo ""


### PR DESCRIPTION
## Summary

Pin Solana and Rust toolchain versions for consistent builds:
- Set Solana version to 1.17.34 in Anchor.toml
- Pin Rust toolchain to 1.78.0 via rust-toolchain.toml
- Improve test.sh watch mode by excluding common build/dependency directories from file watching