### PR TITLE
Add `return_funds` instruction to Launchpad v6

### DIFF
--- a/programs/v06_launchpad/src/error.rs
+++ b/programs/v06_launchpad/src/error.rs
@@ -46,4 +46,6 @@ pub enum LaunchpadError {
     LaunchNotLive,
     #[msg("Minimum raise amount must be greater than or equal to $0.5 so that there's enough liquidity for the launch")]
     InvalidMinimumRaiseAmount,
+    #[msg("Invalid admin")]
+    InvalidAdmin,
 }

--- a/programs/v06_launchpad/src/events.rs
+++ b/programs/v06_launchpad/src/events.rs
@@ -93,3 +93,11 @@ pub struct LaunchCloseEvent {
     pub launch: Pubkey,
     pub new_state: LaunchState,
 }
+
+#[event]
+pub struct LaunchFundsReturnedEvent {
+    pub common: CommonFields,
+    pub launch: Pubkey,
+    pub recipient: Pubkey,
+    pub usdc_returned: u64,
+}

--- a/programs/v06_launchpad/src/instructions/mod.rs
+++ b/programs/v06_launchpad/src/instructions/mod.rs
@@ -4,6 +4,7 @@ pub mod complete_launch;
 pub mod fund;
 pub mod initialize_launch;
 pub mod refund;
+pub mod return_funds;
 pub mod start_launch;
 
 pub use claim::*;
@@ -12,4 +13,5 @@ pub use complete_launch::*;
 pub use fund::*;
 pub use initialize_launch::*;
 pub use refund::*;
+pub use return_funds::*;
 pub use start_launch::*;

--- a/programs/v06_launchpad/src/instructions/return_funds.rs
+++ b/programs/v06_launchpad/src/instructions/return_funds.rs
@@ -1,0 +1,96 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, TokenAccount, Transfer};
+
+use crate::events::{CommonFields, LaunchFundsReturnedEvent};
+use crate::state::Launch;
+
+pub mod admin {
+    use anchor_lang::prelude::declare_id;
+
+    // MetaDAO multisig vault
+    declare_id!("6awyHMshBGVjJ3ozdSJdyyDE1CTAXUwrpNMaRGMsb4sf");
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
+pub struct ReturnFundsArgs {
+    pub amount: u64,
+}
+
+#[event_cpi]
+#[derive(Accounts)]
+pub struct ReturnFunds<'info> {
+    pub admin: Signer<'info>,
+
+    #[account(
+        mut,
+        has_one = launch_quote_vault,
+        has_one = launch_signer,
+    )]
+    pub launch: Account<'info, Launch>,
+
+    #[account(mut)]
+    pub launch_quote_vault: Account<'info, TokenAccount>,
+
+    /// CHECK: This is the launch signer
+    #[account(
+        seeds = [b"launch_signer", launch.key().as_ref()],
+        bump
+    )]
+    pub launch_signer: UncheckedAccount<'info>,
+
+    /// CHECK: not used, just for constraints
+    pub recipient: UncheckedAccount<'info>,
+
+    #[account(mut, associated_token::mint = launch.quote_mint, associated_token::authority = recipient)]
+    pub recipient_quote_account: Account<'info, TokenAccount>,
+
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+}
+
+impl ReturnFunds<'_> {
+    pub fn validate(&self) -> Result<()> {
+        #[cfg(feature = "production")]
+        require_keys_eq!(self.admin.key(), admin::ID, LaunchpadError::InvalidAdmin);
+
+        Ok(())
+    }
+
+    pub fn handle(ctx: Context<Self>, args: ReturnFundsArgs) -> Result<()> {
+        let launch = &mut ctx.accounts.launch;
+        let launch_key = launch.key();
+
+        let seeds = &[
+            b"launch_signer",
+            launch_key.as_ref(),
+            &[launch.launch_signer_pda_bump],
+        ];
+        let signer = &[&seeds[..]];
+
+        // Transfer USDC back to the recipient
+        token::transfer(
+            CpiContext::new_with_signer(
+                ctx.accounts.token_program.to_account_info(),
+                Transfer {
+                    from: ctx.accounts.launch_quote_vault.to_account_info(),
+                    to: ctx.accounts.recipient_quote_account.to_account_info(),
+                    authority: ctx.accounts.launch_signer.to_account_info(),
+                },
+                signer,
+            ),
+            args.amount,
+        )?;
+
+        launch.seq_num += 1;
+
+        let clock = Clock::get()?;
+        emit_cpi!(LaunchFundsReturnedEvent {
+            common: CommonFields::new(&clock, launch.seq_num),
+            launch: ctx.accounts.launch.key(),
+            recipient: ctx.accounts.recipient.key(),
+            usdc_returned: args.amount,
+        });
+
+        Ok(())
+    }
+}

--- a/programs/v06_launchpad/src/lib.rs
+++ b/programs/v06_launchpad/src/lib.rs
@@ -90,4 +90,9 @@ pub mod launchpad {
     pub fn close_launch(ctx: Context<CloseLaunch>) -> Result<()> {
         CloseLaunch::handle(ctx)
     }
+
+    #[access_control(ctx.accounts.validate())]
+    pub fn return_funds(ctx: Context<ReturnFunds>, args: ReturnFundsArgs) -> Result<()> {
+        ReturnFunds::handle(ctx, args)
+    }
 }

--- a/sdk/src/v0.6/types/launchpad.ts
+++ b/sdk/src/v0.6/types/launchpad.ts
@@ -579,6 +579,69 @@ export type Launchpad = {
       ];
       args: [];
     },
+    {
+      name: "returnFunds";
+      accounts: [
+        {
+          name: "admin";
+          isMut: false;
+          isSigner: true;
+        },
+        {
+          name: "launch";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "launchQuoteVault";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "launchSigner";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "recipient";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "recipientQuoteAccount";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "tokenProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "systemProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "eventAuthority";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "program";
+          isMut: false;
+          isSigner: false;
+        },
+      ];
+      args: [
+        {
+          name: "args";
+          type: {
+            defined: "ReturnFundsArgs";
+          };
+        },
+      ];
+    },
   ];
   accounts: [
     {
@@ -873,6 +936,18 @@ export type Launchpad = {
           {
             name: "teamAddress";
             type: "publicKey";
+          },
+        ];
+      };
+    },
+    {
+      name: "ReturnFundsArgs";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "amount";
+            type: "u64";
           },
         ];
       };
@@ -1203,6 +1278,33 @@ export type Launchpad = {
         },
       ];
     },
+    {
+      name: "LaunchFundsReturnedEvent";
+      fields: [
+        {
+          name: "common";
+          type: {
+            defined: "CommonFields";
+          };
+          index: false;
+        },
+        {
+          name: "launch";
+          type: "publicKey";
+          index: false;
+        },
+        {
+          name: "recipient";
+          type: "publicKey";
+          index: false;
+        },
+        {
+          name: "usdcReturned";
+          type: "u64";
+          index: false;
+        },
+      ];
+    },
   ];
   errors: [
     {
@@ -1314,6 +1416,11 @@ export type Launchpad = {
       code: 6021;
       name: "InvalidMinimumRaiseAmount";
       msg: "Minimum raise amount must be greater than or equal to $0.5 so that there's enough liquidity for the launch";
+    },
+    {
+      code: 6022;
+      name: "InvalidAdmin";
+      msg: "Invalid admin";
     },
   ];
 };
@@ -1899,6 +2006,69 @@ export const IDL: Launchpad = {
       ],
       args: [],
     },
+    {
+      name: "returnFunds",
+      accounts: [
+        {
+          name: "admin",
+          isMut: false,
+          isSigner: true,
+        },
+        {
+          name: "launch",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "launchQuoteVault",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "launchSigner",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "recipient",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "recipientQuoteAccount",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "tokenProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "eventAuthority",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "program",
+          isMut: false,
+          isSigner: false,
+        },
+      ],
+      args: [
+        {
+          name: "args",
+          type: {
+            defined: "ReturnFundsArgs",
+          },
+        },
+      ],
+    },
   ],
   accounts: [
     {
@@ -2193,6 +2363,18 @@ export const IDL: Launchpad = {
           {
             name: "teamAddress",
             type: "publicKey",
+          },
+        ],
+      },
+    },
+    {
+      name: "ReturnFundsArgs",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "amount",
+            type: "u64",
           },
         ],
       },
@@ -2523,6 +2705,33 @@ export const IDL: Launchpad = {
         },
       ],
     },
+    {
+      name: "LaunchFundsReturnedEvent",
+      fields: [
+        {
+          name: "common",
+          type: {
+            defined: "CommonFields",
+          },
+          index: false,
+        },
+        {
+          name: "launch",
+          type: "publicKey",
+          index: false,
+        },
+        {
+          name: "recipient",
+          type: "publicKey",
+          index: false,
+        },
+        {
+          name: "usdcReturned",
+          type: "u64",
+          index: false,
+        },
+      ],
+    },
   ],
   errors: [
     {
@@ -2634,6 +2843,11 @@ export const IDL: Launchpad = {
       code: 6021,
       name: "InvalidMinimumRaiseAmount",
       msg: "Minimum raise amount must be greater than or equal to $0.5 so that there's enough liquidity for the launch",
+    },
+    {
+      code: 6022,
+      name: "InvalidAdmin",
+      msg: "Invalid admin",
     },
   ],
 };

--- a/sdk/src/v0.7/types/launchpad.ts
+++ b/sdk/src/v0.7/types/launchpad.ts
@@ -579,6 +579,69 @@ export type Launchpad = {
       ];
       args: [];
     },
+    {
+      name: "returnFunds";
+      accounts: [
+        {
+          name: "admin";
+          isMut: false;
+          isSigner: true;
+        },
+        {
+          name: "launch";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "launchQuoteVault";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "launchSigner";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "recipient";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "recipientQuoteAccount";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "tokenProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "systemProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "eventAuthority";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "program";
+          isMut: false;
+          isSigner: false;
+        },
+      ];
+      args: [
+        {
+          name: "args";
+          type: {
+            defined: "ReturnFundsArgs";
+          };
+        },
+      ];
+    },
   ];
   accounts: [
     {
@@ -873,6 +936,18 @@ export type Launchpad = {
           {
             name: "teamAddress";
             type: "publicKey";
+          },
+        ];
+      };
+    },
+    {
+      name: "ReturnFundsArgs";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "amount";
+            type: "u64";
           },
         ];
       };
@@ -1203,6 +1278,33 @@ export type Launchpad = {
         },
       ];
     },
+    {
+      name: "LaunchFundsReturnedEvent";
+      fields: [
+        {
+          name: "common";
+          type: {
+            defined: "CommonFields";
+          };
+          index: false;
+        },
+        {
+          name: "launch";
+          type: "publicKey";
+          index: false;
+        },
+        {
+          name: "recipient";
+          type: "publicKey";
+          index: false;
+        },
+        {
+          name: "usdcReturned";
+          type: "u64";
+          index: false;
+        },
+      ];
+    },
   ];
   errors: [
     {
@@ -1314,6 +1416,11 @@ export type Launchpad = {
       code: 6021;
       name: "InvalidMinimumRaiseAmount";
       msg: "Minimum raise amount must be greater than or equal to $0.5 so that there's enough liquidity for the launch";
+    },
+    {
+      code: 6022;
+      name: "InvalidAdmin";
+      msg: "Invalid admin";
     },
   ];
 };
@@ -1899,6 +2006,69 @@ export const IDL: Launchpad = {
       ],
       args: [],
     },
+    {
+      name: "returnFunds",
+      accounts: [
+        {
+          name: "admin",
+          isMut: false,
+          isSigner: true,
+        },
+        {
+          name: "launch",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "launchQuoteVault",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "launchSigner",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "recipient",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "recipientQuoteAccount",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "tokenProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "systemProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "eventAuthority",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "program",
+          isMut: false,
+          isSigner: false,
+        },
+      ],
+      args: [
+        {
+          name: "args",
+          type: {
+            defined: "ReturnFundsArgs",
+          },
+        },
+      ],
+    },
   ],
   accounts: [
     {
@@ -2193,6 +2363,18 @@ export const IDL: Launchpad = {
           {
             name: "teamAddress",
             type: "publicKey",
+          },
+        ],
+      },
+    },
+    {
+      name: "ReturnFundsArgs",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "amount",
+            type: "u64",
           },
         ],
       },
@@ -2523,6 +2705,33 @@ export const IDL: Launchpad = {
         },
       ],
     },
+    {
+      name: "LaunchFundsReturnedEvent",
+      fields: [
+        {
+          name: "common",
+          type: {
+            defined: "CommonFields",
+          },
+          index: false,
+        },
+        {
+          name: "launch",
+          type: "publicKey",
+          index: false,
+        },
+        {
+          name: "recipient",
+          type: "publicKey",
+          index: false,
+        },
+        {
+          name: "usdcReturned",
+          type: "u64",
+          index: false,
+        },
+      ],
+    },
   ],
   errors: [
     {
@@ -2634,6 +2843,11 @@ export const IDL: Launchpad = {
       code: 6021,
       name: "InvalidMinimumRaiseAmount",
       msg: "Minimum raise amount must be greater than or equal to $0.5 so that there's enough liquidity for the launch",
+    },
+    {
+      code: 6022,
+      name: "InvalidAdmin",
+      msg: "Invalid admin",
     },
   ],
 };

--- a/tests/launchpad/main.test.ts
+++ b/tests/launchpad/main.test.ts
@@ -5,6 +5,7 @@ import completeLaunch from "./unit/completeLaunch.test.js";
 import claim from "./unit/claim.test.js";
 import refund from "./unit/refund.test.js";
 import closeLaunch from "./unit/closeLaunch.test.js";
+import returnFunds from "./unit/returnFunds.test.js";
 import { PublicKey } from "@solana/web3.js";
 import {
   LAUNCHPAD_PROGRAM_ID,
@@ -75,4 +76,6 @@ export default function suite() {
   describe("#claim", claim);
   describe("#refund", refund);
   describe("#close_launch", closeLaunch);
+
+  describe("#return_funds", returnFunds);
 }

--- a/tests/launchpad/unit/returnFunds.test.ts
+++ b/tests/launchpad/unit/returnFunds.test.ts
@@ -1,9 +1,4 @@
-import {
-  Keypair,
-  PublicKey,
-  TransactionMessage,
-  VersionedTransaction,
-} from "@solana/web3.js";
+import { Keypair, PublicKey } from "@solana/web3.js";
 import { assert } from "chai";
 import {
   FutarchyClient,
@@ -12,9 +7,11 @@ import {
   MAINNET_USDC,
 } from "@metadaoproject/futarchy/v0.6";
 import { BN } from "bn.js";
-import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+} from "@solana/spl-token";
 import { initializeMintWithSeeds } from "../utils.js";
-import { createLookupTableForTransaction } from "../../utils.js";
 
 export default function suite() {
   let futarchyClient: FutarchyClient;
@@ -84,7 +81,7 @@ export default function suite() {
       true,
     );
 
-    // Transfer wrongly sent USDC to the launch signer
+    // Transfer some USDC to the launch signer, thus simulating wrongful sending of funds
     await this.transfer(
       MAINNET_USDC,
       this.payer,
@@ -102,6 +99,14 @@ export default function suite() {
         launchSigner,
         admin: this.payer.publicKey, // This should be the multisig vault, but without the `production` flag, it can be anyone
       })
+      .preInstructions([
+        createAssociatedTokenAccountIdempotentInstruction(
+          this.payer.publicKey, // When executing through the multisig vault, the payer should be the multisig vault
+          recipientQuoteAccount,
+          this.payer.publicKey,
+          MAINNET_USDC,
+        ),
+      ])
       .rpc();
 
     const finalUsdcBalance = await this.getTokenBalance(

--- a/tests/launchpad/unit/returnFunds.test.ts
+++ b/tests/launchpad/unit/returnFunds.test.ts
@@ -1,0 +1,115 @@
+import {
+  Keypair,
+  PublicKey,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { assert } from "chai";
+import {
+  FutarchyClient,
+  getLaunchSignerAddr,
+  LaunchpadClient,
+  MAINNET_USDC,
+} from "@metadaoproject/futarchy/v0.6";
+import { BN } from "bn.js";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { initializeMintWithSeeds } from "../utils.js";
+import { createLookupTableForTransaction } from "../../utils.js";
+
+export default function suite() {
+  let futarchyClient: FutarchyClient;
+  let launchpadClient: LaunchpadClient;
+  let METAKP: Keypair;
+  let META: PublicKey;
+  let launch: PublicKey;
+  let launchSigner: PublicKey;
+  let quoteVault: PublicKey;
+  let funderQuoteAccount: PublicKey;
+
+  before(async function () {
+    futarchyClient = this.futarchy;
+    launchpadClient = this.launchpad_v6;
+  });
+
+  beforeEach(async function () {
+    const result = await initializeMintWithSeeds(
+      this.banksClient,
+      this.launchpad_v6,
+      this.payer,
+    );
+
+    META = result.tokenMint;
+    launch = result.launch;
+    launchSigner = result.launchSigner;
+    quoteVault = getAssociatedTokenAddressSync(
+      MAINNET_USDC,
+      launchSigner,
+      true,
+    );
+    funderQuoteAccount = getAssociatedTokenAddressSync(
+      MAINNET_USDC,
+      this.payer.publicKey,
+    );
+
+    await this.setupBasicLaunch({
+      baseMint: META,
+      founders: [this.payer.publicKey],
+    });
+
+    await launchpadClient.startLaunchIx({ launch }).rpc();
+  });
+
+  it("returns funds to the recipient", async function () {
+    const amount_wrongly_sent = new BN(100);
+
+    const initialUsdcBalance = await this.getTokenBalance(
+      MAINNET_USDC,
+      this.payer.publicKey,
+    );
+
+    const [launchSigner] = getLaunchSignerAddr(
+      launchpadClient.launchpad.programId,
+      launch,
+    );
+
+    const launchQuoteVault = getAssociatedTokenAddressSync(
+      MAINNET_USDC,
+      launchSigner,
+      true,
+    );
+
+    const recipientQuoteAccount = getAssociatedTokenAddressSync(
+      MAINNET_USDC,
+      this.payer.publicKey,
+      true,
+    );
+
+    // Transfer wrongly sent USDC to the launch signer
+    await this.transfer(
+      MAINNET_USDC,
+      this.payer,
+      launchSigner,
+      amount_wrongly_sent.toNumber(),
+    );
+
+    await launchpadClient.launchpad.methods
+      .returnFunds({ amount: amount_wrongly_sent })
+      .accounts({
+        launch,
+        recipient: this.payer.publicKey,
+        recipientQuoteAccount,
+        launchQuoteVault,
+        launchSigner,
+        admin: this.payer.publicKey, // This should be the multisig vault, but without the `production` flag, it can be anyone
+      })
+      .rpc();
+
+    const finalUsdcBalance = await this.getTokenBalance(
+      MAINNET_USDC,
+      this.payer.publicKey,
+    );
+
+    // The recipient should have received the wrongly sent USDC, thus no balance change
+    assert.equal(finalUsdcBalance, initialUsdcBalance);
+  });
+}


### PR DESCRIPTION
Adds an admin-only instruction that allows the MetaDAO operational multisig to recover USDC from a launch's quote vault by transferring it to a specified recipient.

## Motivation

This instruction serves as a recovery mechanism for funds that may have been mistakenly sent directly to a launch's quote vault outside of normal program flows (e.g., accidental transfers). Without this, such funds would be permanently locked since only the launch's PDA signer can authorize transfers from the vault.

## Changes

- New `return_funds` instruction that transfers a specified amount of USDC from `launch_quote_vault` to a recipient's associated token account
  - Callable only by the MetaDAO operational multisig in production
- New `LaunchFundsReturnedEvent` emitted on each recovery for off-chain tracking
- New `InvalidAdmin` error code

## Notes

- The instruction can be called regardless of launch state (live, completed, failed, etc.) - this is intentional since recovery may be needed at any point
- The admin can specify any recipient address and any amount (up to vault balance)
- No state changes occur on the `Launch` account other than incrementing `seq_num`