### PR TITLE
Backdoor execution of multisig proposals

### DIFF
--- a/programs/futarchy/src/instructions/admin_approve_execute_multisig_proposal.rs
+++ b/programs/futarchy/src/instructions/admin_approve_execute_multisig_proposal.rs
@@ -19,11 +19,33 @@ pub struct AdminApproveExecuteMultisigProposal<'info> {
     #[account(mut, seeds = [squads_multisig_program::SEED_PREFIX, squads_multisig_program::SEED_MULTISIG, dao.key().as_ref()], bump, seeds::program = squads_multisig_program)]
     pub squads_multisig: Account<'info, squads_multisig_program::Multisig>,
     /// CHECK: squads proposal, initialized by squads multisig program, checked by squads multisig program
-    #[account(mut)]
-    pub squads_multisig_proposal: UncheckedAccount<'info>,
+    #[account(
+        mut,
+        seeds = [
+            squads_multisig_program::SEED_PREFIX,
+            squads_multisig.key().as_ref(),
+            squads_multisig_program::SEED_TRANSACTION,
+            squads_multisig_vault_transaction.index.to_le_bytes().as_ref(),
+            squads_multisig_program::SEED_PROPOSAL,
+        ],
+        bump,
+        seeds::program = squads_multisig_program
+    )]
+    pub squads_multisig_proposal: Account<'info, squads_multisig_program::Proposal>,
     /// CHECK: squads vault transaction, initialized by squads multisig program, checked by squads multisig program
-    #[account(mut)]
-    pub squads_multisig_vault_transaction: UncheckedAccount<'info>,
+    #[account(
+        mut,
+        seeds = [
+            squads_multisig_program::SEED_PREFIX,
+            squads_multisig.key().as_ref(),
+            squads_multisig_program::SEED_TRANSACTION,
+            squads_multisig_vault_transaction.index.to_le_bytes().as_ref(),
+        ],
+        bump,
+        seeds::program = squads_multisig_program
+    )]
+    pub squads_multisig_vault_transaction:
+        Account<'info, squads_multisig_program::VaultTransaction>,
 
     pub squads_multisig_program:
         Program<'info, squads_multisig_program::program::SquadsMultisigProgram>,

--- a/programs/futarchy/src/instructions/admin_approve_execute_multisig_proposal.rs
+++ b/programs/futarchy/src/instructions/admin_approve_execute_multisig_proposal.rs
@@ -60,11 +60,8 @@ impl<'info, 'c: 'info> AdminApproveExecuteMultisigProposal<'info> {
             FutarchyError::InvalidAdmin
         );
 
-        match self.dao.amm.state {
-            PoolState::Spot { .. } => {}
-            _ => {
-                return Err(FutarchyError::PoolNotInSpotState.into());
-            }
+        if !matches!(self.dao.amm.state, PoolState::Spot { .. }) {
+            return Err(FutarchyError::PoolNotInSpotState.into());
         }
 
         Ok(())

--- a/programs/futarchy/src/instructions/admin_approve_execute_multisig_proposal.rs
+++ b/programs/futarchy/src/instructions/admin_approve_execute_multisig_proposal.rs
@@ -38,6 +38,13 @@ impl<'info, 'c: 'info> AdminApproveExecuteMultisigProposal<'info> {
             FutarchyError::InvalidAdmin
         );
 
+        match self.dao.amm.state {
+            PoolState::Spot { .. } => {}
+            _ => {
+                return Err(FutarchyError::PoolNotInSpotState.into());
+            }
+        }
+
         Ok(())
     }
 

--- a/programs/futarchy/src/instructions/admin_approve_execute_multisig_proposal.rs
+++ b/programs/futarchy/src/instructions/admin_approve_execute_multisig_proposal.rs
@@ -1,0 +1,92 @@
+use super::*;
+
+pub mod metadao_multisig_vault {
+    use anchor_lang::prelude::declare_id;
+
+    // MetaDAO multisig
+    declare_id!("6awyHMshBGVjJ3ozdSJdyyDE1CTAXUwrpNMaRGMsb4sf");
+}
+
+#[derive(Accounts)]
+#[event_cpi]
+pub struct AdminApproveExecuteMultisigProposal<'info> {
+    #[account(mut, has_one = squads_multisig)]
+    pub dao: Account<'info, Dao>,
+    #[account(mut)]
+    pub admin: Signer<'info>,
+
+    /// CHECK: checked by autocrat program
+    #[account(mut, seeds = [squads_multisig_program::SEED_PREFIX, squads_multisig_program::SEED_MULTISIG, dao.key().as_ref()], bump, seeds::program = squads_multisig_program)]
+    pub squads_multisig: Account<'info, squads_multisig_program::Multisig>,
+    /// CHECK: squads proposal, initialized by squads multisig program, checked by squads multisig program
+    #[account(mut)]
+    pub squads_multisig_proposal: UncheckedAccount<'info>,
+    /// CHECK: squads vault transaction, initialized by squads multisig program, checked by squads multisig program
+    #[account(mut)]
+    pub squads_multisig_vault_transaction: UncheckedAccount<'info>,
+
+    pub squads_multisig_program:
+        Program<'info, squads_multisig_program::program::SquadsMultisigProgram>,
+}
+
+impl<'info, 'c: 'info> AdminApproveExecuteMultisigProposal<'info> {
+    pub fn validate(&self) -> Result<()> {
+        #[cfg(feature = "production")]
+        require_keys_eq!(
+            self.admin.key(),
+            metadao_multisig_vault::ID,
+            FutarchyError::InvalidAdmin
+        );
+
+        Ok(())
+    }
+
+    pub fn handle(ctx: Context<'_, '_, 'c, 'info, Self>) -> Result<()> {
+        let Self {
+            dao,
+            admin: _,
+            squads_multisig,
+            squads_multisig_proposal,
+            squads_multisig_vault_transaction,
+            squads_multisig_program,
+            event_authority: _,
+            program: _,
+        } = ctx.accounts;
+
+        let dao_nonce = &dao.nonce.to_le_bytes();
+        let dao_creator_key = &dao.dao_creator.as_ref();
+        let dao_seeds = &[b"dao".as_ref(), dao_creator_key, dao_nonce, &[dao.pda_bump]];
+        let dao_signer = &[&dao_seeds[..]];
+
+        // Approve the proposal
+        squads_multisig_program::cpi::proposal_approve(
+            CpiContext::new_with_signer(
+                squads_multisig_program.to_account_info(),
+                squads_multisig_program::cpi::accounts::ProposalVote {
+                    proposal: squads_multisig_proposal.to_account_info(),
+                    multisig: squads_multisig.to_account_info(),
+                    member: dao.to_account_info(),
+                },
+                dao_signer,
+            ),
+            squads_multisig_program::ProposalVoteArgs { memo: None },
+        )?;
+
+        // Execute the vault transaction
+        squads_multisig_program::cpi::vault_transaction_execute(
+            CpiContext::new_with_signer(
+                squads_multisig_program.to_account_info(),
+                squads_multisig_program::cpi::accounts::VaultTransactionExecute {
+                    multisig: squads_multisig.to_account_info(),
+                    proposal: squads_multisig_proposal.to_account_info(),
+                    transaction: squads_multisig_vault_transaction.to_account_info(),
+                    member: dao.to_account_info(),
+                },
+                dao_signer,
+            )
+            .with_remaining_accounts((&ctx.remaining_accounts).to_vec()),
+        )?;
+
+        Ok(())
+    }
+}

--- a/programs/futarchy/src/instructions/execute_spending_limit_change.rs
+++ b/programs/futarchy/src/instructions/execute_spending_limit_change.rs
@@ -25,11 +25,8 @@ impl<'info, 'c: 'info> ExecuteSpendingLimitChange<'info> {
     pub fn validate(&self) -> Result<()> {
         require_eq!(self.proposal.state, ProposalState::Passed);
 
-        match self.dao.amm.state {
-            PoolState::Spot { .. } => {}
-            _ => {
-                return Err(FutarchyError::PoolNotInSpotState.into());
-            }
+        if !matches!(self.dao.amm.state, PoolState::Spot { .. }) {
+            return Err(FutarchyError::PoolNotInSpotState.into());
         }
 
         Ok(())

--- a/programs/futarchy/src/instructions/execute_spending_limit_change.rs
+++ b/programs/futarchy/src/instructions/execute_spending_limit_change.rs
@@ -25,6 +25,13 @@ impl<'info, 'c: 'info> ExecuteSpendingLimitChange<'info> {
     pub fn validate(&self) -> Result<()> {
         require_eq!(self.proposal.state, ProposalState::Passed);
 
+        match self.dao.amm.state {
+            PoolState::Spot { .. } => {}
+            _ => {
+                return Err(FutarchyError::PoolNotInSpotState.into());
+            }
+        }
+
         Ok(())
     }
 

--- a/programs/futarchy/src/instructions/initialize_proposal.rs
+++ b/programs/futarchy/src/instructions/initialize_proposal.rs
@@ -12,6 +12,7 @@ pub struct InitializeProposal<'info> {
     )]
     pub proposal: Box<Account<'info, Proposal>>,
     pub squads_proposal: Box<Account<'info, squads_multisig_program::Proposal>>,
+    pub squads_multisig: Box<Account<'info, squads_multisig_program::Multisig>>,
     #[account(mut)]
     pub dao: Box<Account<'info, Dao>>,
     #[account(
@@ -52,6 +53,12 @@ impl InitializeProposal<'_> {
             }
         }
 
+        // Ensure the squads proposal is not invalidated by a previous config transaction
+        require_gt!(
+            self.squads_proposal.transaction_index,
+            self.squads_multisig.stale_transaction_index
+        );
+
         // Should never be the case because the oracle is the proposal account, and you can't re-initialize a proposal
         assert!(!self.question.is_resolved());
 
@@ -65,6 +72,7 @@ impl InitializeProposal<'_> {
             question,
             proposal,
             squads_proposal,
+            squads_multisig: _,
             dao,
             proposer,
             payer: _,

--- a/programs/futarchy/src/instructions/launch_proposal.rs
+++ b/programs/futarchy/src/instructions/launch_proposal.rs
@@ -27,7 +27,9 @@ pub struct LaunchProposal<'info> {
     pub amm_fail_base_vault: Box<Account<'info, TokenAccount>>,
     #[account(init_if_needed, payer = payer, associated_token::mint = fail_quote_mint, associated_token::authority = dao)]
     pub amm_fail_quote_vault: Box<Account<'info, TokenAccount>>,
+    #[account(seeds = [squads_multisig_program::SEED_PREFIX, squads_multisig_program::SEED_MULTISIG, dao.key().as_ref()], bump, seeds::program = squads_multisig_program::ID)]
     pub squads_multisig: Account<'info, squads_multisig_program::Multisig>,
+    #[account(owner = squads_multisig_program::ID)]
     pub squads_proposal: Account<'info, squads_multisig_program::Proposal>,
     pub system_program: Program<'info, System>,
     pub token_program: Program<'info, Token>,

--- a/programs/futarchy/src/instructions/launch_proposal.rs
+++ b/programs/futarchy/src/instructions/launch_proposal.rs
@@ -3,7 +3,7 @@ use super::*;
 #[derive(Accounts)]
 #[event_cpi]
 pub struct LaunchProposal<'info> {
-    #[account(mut, has_one = dao, has_one = quote_vault, has_one = base_vault)]
+    #[account(mut, has_one = dao, has_one = quote_vault, has_one = base_vault, has_one = squads_proposal)]
     pub proposal: Box<Account<'info, Proposal>>,
     pub base_vault: Box<Account<'info, ConditionalVault>>,
     pub quote_vault: Box<Account<'info, ConditionalVault>>,
@@ -15,7 +15,7 @@ pub struct LaunchProposal<'info> {
     pub fail_base_mint: Box<Account<'info, Mint>>,
     #[account(address = quote_vault.conditional_token_mints[0])]
     pub fail_quote_mint: Box<Account<'info, Mint>>,
-    #[account(mut)]
+    #[account(mut, has_one = squads_multisig)]
     pub dao: Box<Account<'info, Dao>>,
     #[account(mut)]
     pub payer: Signer<'info>,
@@ -27,6 +27,8 @@ pub struct LaunchProposal<'info> {
     pub amm_fail_base_vault: Box<Account<'info, TokenAccount>>,
     #[account(init_if_needed, payer = payer, associated_token::mint = fail_quote_mint, associated_token::authority = dao)]
     pub amm_fail_quote_vault: Box<Account<'info, TokenAccount>>,
+    pub squads_multisig: Account<'info, squads_multisig_program::Multisig>,
+    pub squads_proposal: Account<'info, squads_multisig_program::Proposal>,
     pub system_program: Program<'info, System>,
     pub token_program: Program<'info, Token>,
     pub associated_token_program: Program<'info, AssociatedToken>,
@@ -51,6 +53,12 @@ impl LaunchProposal<'_> {
             );
         }
 
+        // Ensure the squads proposal is not invalidated by a previous config transaction
+        require_gt!(
+            self.squads_proposal.transaction_index,
+            self.squads_multisig.stale_transaction_index
+        );
+
         Ok(())
     }
 
@@ -72,6 +80,8 @@ impl LaunchProposal<'_> {
             amm_pass_quote_vault: _,
             amm_fail_base_vault: _,
             amm_fail_quote_vault: _,
+            squads_multisig: _,
+            squads_proposal: _,
             system_program: _,
             token_program: _,
             associated_token_program: _,

--- a/programs/futarchy/src/instructions/mod.rs
+++ b/programs/futarchy/src/instructions/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+pub mod admin_approve_execute_multisig_proposal;
 pub mod collect_fees;
 pub mod collect_meteora_damm_fees;
 pub mod conditional_swap;
@@ -16,6 +17,7 @@ pub mod unstake_from_proposal;
 pub mod update_dao;
 pub mod withdraw_liquidity;
 
+pub use admin_approve_execute_multisig_proposal::*;
 pub use collect_fees::*;
 pub use collect_meteora_damm_fees::*;
 pub use conditional_swap::*;

--- a/programs/futarchy/src/lib.rs
+++ b/programs/futarchy/src/lib.rs
@@ -147,4 +147,11 @@ pub mod futarchy {
     pub fn collect_meteora_damm_fees(ctx: Context<CollectMeteoraDammFees>) -> Result<()> {
         CollectMeteoraDammFees::handle(ctx)
     }
+
+    #[access_control(ctx.accounts.validate())]
+    pub fn admin_approve_execute_multisig_proposal<'c: 'info, 'info>(
+        ctx: Context<'_, '_, 'c, 'info, AdminApproveExecuteMultisigProposal<'info>>,
+    ) -> Result<()> {
+        AdminApproveExecuteMultisigProposal::handle(ctx)
+    }
 }

--- a/sdk/src/v0.7/FutarchyClient.ts
+++ b/sdk/src/v0.7/FutarchyClient.ts
@@ -279,11 +279,13 @@ export class FutarchyClient {
     dao,
     baseMint,
     quoteMint,
+    squadsProposal,
   }: {
     proposal: PublicKey;
     dao: PublicKey;
     baseMint: PublicKey;
     quoteMint: PublicKey;
+    squadsProposal: PublicKey;
   }) {
     const {
       baseVault,
@@ -293,6 +295,8 @@ export class FutarchyClient {
       failBaseMint,
       failQuoteMint,
     } = this.getProposalPdas(proposal, baseMint, quoteMint, dao);
+
+    const squadsMultisig = multisig.getMultisigPda({ createKey: dao })[0];
 
     return this.autocrat.methods
       .launchProposal()
@@ -325,6 +329,8 @@ export class FutarchyClient {
           dao,
           true,
         ),
+        squadsMultisig,
+        squadsProposal,
         payer: this.provider.publicKey,
       })
       .preInstructions([
@@ -695,6 +701,8 @@ export class FutarchyClient {
       this.getProgramId(),
     );
 
+    const squadsMultisig = multisig.getMultisigPda({ createKey: dao })[0];
+
     return this.autocrat.methods
       .initializeProposal()
       .accounts({
@@ -705,6 +713,7 @@ export class FutarchyClient {
         baseVault,
         quoteVault,
         proposer,
+        squadsMultisig,
       })
       .preInstructions([
         createAssociatedTokenAccountIdempotentInstruction(

--- a/sdk/src/v0.7/types/futarchy.ts
+++ b/sdk/src/v0.7/types/futarchy.ts
@@ -119,6 +119,11 @@ export type Futarchy = {
           isSigner: false;
         },
         {
+          name: "squadsMultisig";
+          isMut: false;
+          isSigner: false;
+        },
+        {
           name: "dao";
           isMut: true;
           isSigner: false;
@@ -368,6 +373,16 @@ export type Futarchy = {
         {
           name: "ammFailQuoteVault";
           isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "squadsMultisig";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "squadsProposal";
+          isMut: false;
           isSigner: false;
         },
         {
@@ -3094,6 +3109,11 @@ export const IDL: Futarchy = {
           isSigner: false,
         },
         {
+          name: "squadsMultisig",
+          isMut: false,
+          isSigner: false,
+        },
+        {
           name: "dao",
           isMut: true,
           isSigner: false,
@@ -3343,6 +3363,16 @@ export const IDL: Futarchy = {
         {
           name: "ammFailQuoteVault",
           isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "squadsMultisig",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "squadsProposal",
+          isMut: false,
           isSigner: false,
         },
         {

--- a/sdk/src/v0.7/types/futarchy.ts
+++ b/sdk/src/v0.7/types/futarchy.ts
@@ -1170,6 +1170,52 @@ export type Futarchy = {
       ];
       args: [];
     },
+    {
+      name: "adminApproveExecuteMultisigProposal";
+      accounts: [
+        {
+          name: "dao";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "admin";
+          isMut: true;
+          isSigner: true;
+        },
+        {
+          name: "squadsMultisig";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "squadsMultisigProposal";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "squadsMultisigVaultTransaction";
+          isMut: true;
+          isSigner: false;
+        },
+        {
+          name: "squadsMultisigProgram";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "eventAuthority";
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: "program";
+          isMut: false;
+          isSigner: false;
+        },
+      ];
+      args: [];
+    },
   ];
   accounts: [
     {
@@ -4083,6 +4129,52 @@ export const IDL: Futarchy = {
         },
         {
           name: "squadsProgram",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "eventAuthority",
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: "program",
+          isMut: false,
+          isSigner: false,
+        },
+      ],
+      args: [],
+    },
+    {
+      name: "adminApproveExecuteMultisigProposal",
+      accounts: [
+        {
+          name: "dao",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "admin",
+          isMut: true,
+          isSigner: true,
+        },
+        {
+          name: "squadsMultisig",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "squadsMultisigProposal",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "squadsMultisigVaultTransaction",
+          isMut: true,
+          isSigner: false,
+        },
+        {
+          name: "squadsMultisigProgram",
           isMut: false,
           isSigner: false,
         },

--- a/tests/futarchy/integration/futarchyAmm.test.ts
+++ b/tests/futarchy/integration/futarchyAmm.test.ts
@@ -211,8 +211,16 @@ export default function suite() {
       dao,
     );
 
+    const proposalAccount = await this.futarchy.getProposal(proposal);
+
     await this.futarchy
-      .launchProposalIx({ proposal, dao, baseMint: META, quoteMint: USDC })
+      .launchProposalIx({
+        proposal,
+        dao,
+        baseMint: META,
+        quoteMint: USDC,
+        squadsProposal: proposalAccount.squadsProposal,
+      })
       .rpc();
 
     await this.futarchy

--- a/tests/futarchy/main.test.ts
+++ b/tests/futarchy/main.test.ts
@@ -10,6 +10,8 @@ import conditionalSwap from "./unit/conditionalSwap.test.js";
 import executeSpendingLimitChange from "./unit/executeSpendingLimitChange.test.js";
 
 import collectMeteoraDammFees from "./unit/collectMeteoraDammFees.test.js";
+import adminApproveProposal from "./unit/adminApproveExecuteMultisigProposal.test.js";
+
 import { PublicKey } from "@solana/web3.js";
 import {
   LAUNCHPAD_PROGRAM_ID,
@@ -50,6 +52,7 @@ export default function suite() {
 
   describe("#collect_meteora_damm_fees", collectMeteoraDammFees);
 
+  describe("#admin_approve_proposal", adminApproveProposal);
   // describe("full proposal", fullProposal);
   // describe("proposal with a squads batch tx", proposalBatchTx);
   describe("futarchy amm", futarchyAmm);

--- a/tests/futarchy/unit/adminApproveExecuteMultisigProposal.test.ts
+++ b/tests/futarchy/unit/adminApproveExecuteMultisigProposal.test.ts
@@ -1,0 +1,243 @@
+import { PERMISSIONLESS_ACCOUNT } from "@metadaoproject/futarchy/v0.6";
+import { PublicKey, Transaction, TransactionMessage } from "@solana/web3.js";
+import { expectError, setupBasicDao } from "../../utils.js";
+import { assert } from "chai";
+import * as multisig from "@sqds/multisig";
+import { createMemoInstruction } from "@solana/spl-memo";
+
+export default function suite() {
+  let META: PublicKey, USDC: PublicKey, dao: PublicKey;
+
+  beforeEach(async function () {
+    META = await this.createMint(this.payer.publicKey, 9);
+    USDC = await this.createMint(this.payer.publicKey, 6);
+
+    // Create payer's token accounts for both mints
+    await this.createTokenAccount(META, this.payer.publicKey);
+    await this.createTokenAccount(USDC, this.payer.publicKey);
+
+    // Mint tokens to payer's accounts
+    await this.mintTo(META, this.payer.publicKey, this.payer, 100 * 10 ** 9);
+    await this.mintTo(
+      USDC,
+      this.payer.publicKey,
+      this.payer,
+      100_000 * 1_000_000,
+    );
+
+    dao = await setupBasicDao({
+      context: this,
+      baseMint: META,
+      quoteMint: USDC,
+    });
+  });
+
+  it("should approve a squads proposal with a config transaction that belongs to the DAO's multisig", async function () {
+    const daoAccount = await this.futarchy.getDao(dao);
+
+    // Create a vault transaction that will be invalidated by the config transaction
+    const vaultTransactionToInvalidateCreateIx =
+      multisig.instructions.vaultTransactionCreate({
+        multisigPda: daoAccount.squadsMultisig,
+        transactionIndex: 1n,
+        creator: PERMISSIONLESS_ACCOUNT.publicKey,
+        rentPayer: this.payer.publicKey,
+        vaultIndex: 0,
+        transactionMessage: new TransactionMessage({
+          payerKey: this.payer.publicKey,
+          recentBlockhash: (await this.banksClient.getLatestBlockhash())[0],
+          instructions: [
+            createMemoInstruction("I will never see the light of day"),
+          ],
+        }),
+        ephemeralSigners: 0,
+      });
+
+    const vaultProposalToInvalidateCreateIx =
+      multisig.instructions.proposalCreate({
+        multisigPda: daoAccount.squadsMultisig,
+        transactionIndex: 1n,
+        creator: PERMISSIONLESS_ACCOUNT.publicKey,
+        rentPayer: this.payer.publicKey,
+      });
+
+    const configTransactionIndex = 2n;
+
+    const multisigSetTimeLockIx = multisig.instructions.multisigSetTimeLock({
+      multisigPda: daoAccount.squadsMultisig,
+      timeLock: 100,
+      configAuthority: dao,
+    });
+
+    const setTimeLockMessage = new TransactionMessage({
+      payerKey: this.payer.publicKey,
+      recentBlockhash: (await this.banksClient.getLatestBlockhash())[0],
+      instructions: [multisigSetTimeLockIx],
+    });
+
+    const vaultConfigTransactionCreateIx =
+      multisig.instructions.vaultTransactionCreate({
+        multisigPda: daoAccount.squadsMultisig,
+        transactionIndex: configTransactionIndex,
+        creator: PERMISSIONLESS_ACCOUNT.publicKey,
+        rentPayer: this.payer.publicKey,
+        vaultIndex: 0,
+        ephemeralSigners: 0,
+        transactionMessage: setTimeLockMessage,
+      });
+
+    const multisigConfigProposalCreateIx = multisig.instructions.proposalCreate(
+      {
+        multisigPda: daoAccount.squadsMultisig,
+        transactionIndex: configTransactionIndex,
+        creator: PERMISSIONLESS_ACCOUNT.publicKey,
+        rentPayer: this.payer.publicKey,
+      },
+    );
+
+    // Create the squads proposal first
+    const squadsTransactionsCreateTx = new Transaction().add(
+      vaultTransactionToInvalidateCreateIx,
+      vaultProposalToInvalidateCreateIx,
+      vaultConfigTransactionCreateIx,
+      multisigConfigProposalCreateIx,
+    );
+    squadsTransactionsCreateTx.recentBlockhash = (
+      await this.banksClient.getLatestBlockhash()
+    )[0];
+    squadsTransactionsCreateTx.feePayer = this.payer.publicKey;
+    squadsTransactionsCreateTx.sign(this.payer, PERMISSIONLESS_ACCOUNT);
+
+    await this.banksClient.processTransaction(squadsTransactionsCreateTx);
+
+    const [vaultConfigTransactionPda] = multisig.getTransactionPda({
+      multisigPda: daoAccount.squadsMultisig,
+      index: configTransactionIndex,
+    });
+
+    const [squadsConfigProposalPda] = multisig.getProposalPda({
+      multisigPda: daoAccount.squadsMultisig,
+      transactionIndex: configTransactionIndex,
+    });
+
+    const configTransactionAccount =
+      await multisig.accounts.VaultTransaction.fromAccountAddress(
+        this.squadsConnection,
+        vaultConfigTransactionPda,
+      );
+
+    const { accountMetas: configTransactionAccountMetas } =
+      await multisig.utils.accountsForTransactionExecute({
+        connection: this.squadsConnection,
+        message: configTransactionAccount.message,
+        ephemeralSignerBumps: [
+          ...configTransactionAccount.ephemeralSignerBumps,
+        ],
+        vaultPda: daoAccount.squadsMultisigVault,
+        transactionPda: vaultConfigTransactionPda,
+        programId: multisig.PROGRAM_ID,
+      });
+
+    let squadsConfigProposal =
+      await multisig.accounts.Proposal.fromAccountAddress(
+        this.squadsConnection,
+        squadsConfigProposalPda,
+      );
+
+    assert.equal(squadsConfigProposal.transactionIndex, 2); // We're looking at the correct proposal
+    assert.equal(squadsConfigProposal.approved.length, 0); // Should have zero approvals
+    assert.isTrue(
+      multisig.generated.isProposalStatusActive(squadsConfigProposal.status),
+    );
+
+    await this.futarchy.autocrat.methods
+      .adminApproveExecuteMultisigProposal()
+      .accounts({
+        dao: dao,
+        squadsMultisig: daoAccount.squadsMultisig,
+        squadsMultisigProposal: squadsConfigProposalPda,
+        squadsMultisigVaultTransaction: vaultConfigTransactionPda,
+        admin: this.payer.publicKey,
+        squadsMultisigProgram: multisig.PROGRAM_ID,
+      })
+      .remainingAccounts(
+        configTransactionAccountMetas.map((meta) =>
+          meta.pubkey.equals(dao) ? { ...meta, isSigner: false } : meta,
+        ),
+      )
+      .signers([this.payer])
+      .rpc();
+
+    squadsConfigProposal = await multisig.accounts.Proposal.fromAccountAddress(
+      this.squadsConnection,
+      squadsConfigProposalPda,
+    );
+
+    assert.equal(squadsConfigProposal.transactionIndex, 2); // We're looking at the correct proposal
+    assert.equal(squadsConfigProposal.approved[0].toBase58(), dao.toBase58()); // Should have DAO approval
+    assert.isTrue(
+      multisig.generated.isProposalStatusExecuted(squadsConfigProposal.status),
+    );
+
+    // Confirm that vault transactions before the config transaction are invalidated
+    const squadsMultisig = await multisig.accounts.Multisig.fromAccountAddress(
+      this.squadsConnection,
+      daoAccount.squadsMultisig,
+    );
+    assert.equal(squadsMultisig.staleTransactionIndex, 2);
+
+    // Attempt to execute the invalidated vault transaction
+    // We could run a regular futarchy market as well here, but we can also just shortcut it using the admin function
+    const [vaultInvalidatedTransactionPda] = multisig.getTransactionPda({
+      multisigPda: daoAccount.squadsMultisig,
+      index: configTransactionIndex,
+    });
+
+    const [squadsInvalidatedProposalPda] = multisig.getProposalPda({
+      multisigPda: daoAccount.squadsMultisig,
+      transactionIndex: configTransactionIndex,
+    });
+
+    const invalidatedTransactionAccount =
+      await multisig.accounts.VaultTransaction.fromAccountAddress(
+        this.squadsConnection,
+        vaultInvalidatedTransactionPda,
+      );
+
+    const { accountMetas: invalidatedTransactionAccountMetas } =
+      await multisig.utils.accountsForTransactionExecute({
+        connection: this.squadsConnection,
+        message: configTransactionAccount.message,
+        ephemeralSignerBumps: [
+          ...configTransactionAccount.ephemeralSignerBumps,
+        ],
+        vaultPda: daoAccount.squadsMultisigVault,
+        transactionPda: vaultInvalidatedTransactionPda,
+        programId: multisig.PROGRAM_ID,
+      });
+
+    const callbacks = expectError(
+      "InvalidProposalStatus",
+      "The proposal should not be executed because it should have been invalidated",
+    );
+
+    await this.futarchy.autocrat.methods
+      .adminApproveExecuteMultisigProposal()
+      .accounts({
+        dao: dao,
+        squadsMultisig: daoAccount.squadsMultisig,
+        squadsMultisigProposal: squadsInvalidatedProposalPda,
+        squadsMultisigVaultTransaction: vaultInvalidatedTransactionPda,
+        admin: this.payer.publicKey,
+        squadsMultisigProgram: multisig.PROGRAM_ID,
+      })
+      .remainingAccounts(
+        invalidatedTransactionAccountMetas.map((meta) =>
+          meta.pubkey.equals(dao) ? { ...meta, isSigner: false } : meta,
+        ),
+      )
+      .signers([this.payer])
+      .rpc()
+      .then(callbacks[0], callbacks[1]);
+  });
+}

--- a/tests/futarchy/unit/adminApproveExecuteMultisigProposal.test.ts
+++ b/tests/futarchy/unit/adminApproveExecuteMultisigProposal.test.ts
@@ -1,5 +1,10 @@
 import { PERMISSIONLESS_ACCOUNT } from "@metadaoproject/futarchy/v0.6";
-import { PublicKey, Transaction, TransactionMessage } from "@solana/web3.js";
+import {
+  ComputeBudgetProgram,
+  PublicKey,
+  Transaction,
+  TransactionMessage,
+} from "@solana/web3.js";
 import { expectError, setupBasicDao } from "../../utils.js";
 import { assert } from "chai";
 import * as multisig from "@sqds/multisig";
@@ -236,6 +241,9 @@ export default function suite() {
           meta.pubkey.equals(dao) ? { ...meta, isSigner: false } : meta,
         ),
       )
+      .preInstructions([
+        ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1 }),
+      ])
       .signers([this.payer])
       .rpc()
       .then(callbacks[0], callbacks[1]);

--- a/tests/futarchy/unit/finalizeProposal.test.ts
+++ b/tests/futarchy/unit/finalizeProposal.test.ts
@@ -70,6 +70,9 @@ export default function suite() {
           twapMaxObservationChangePerUpdate: null,
           minQuoteFutarchicLiquidity: null,
           minBaseFutarchicLiquidity: null,
+          twapStartDelaySeconds: null,
+          teamSponsoredPassThresholdBps: null,
+          teamAddress: null,
         },
       })
       .instruction();
@@ -120,6 +123,7 @@ export default function suite() {
         dao,
         baseMint: META,
         quoteMint: USDC,
+        squadsProposal: squadsProposalPda,
       })
       .rpc();
   });
@@ -347,6 +351,9 @@ export default function suite() {
           twapMaxObservationChangePerUpdate: null,
           minQuoteFutarchicLiquidity: null,
           minBaseFutarchicLiquidity: null,
+          twapStartDelaySeconds: null,
+          teamSponsoredPassThresholdBps: null,
+          teamAddress: null,
         },
       })
       .instruction();
@@ -411,6 +418,7 @@ export default function suite() {
         dao: daoWithTeamSponsorship,
         baseMint: META,
         quoteMint: USDC,
+        squadsProposal: squadsProposalPda,
       })
       .rpc();
 

--- a/tests/integration/fullLaunch.test.ts
+++ b/tests/integration/fullLaunch.test.ts
@@ -462,6 +462,7 @@ export default async function suite() {
         dao,
         baseMint: META,
         quoteMint: MAINNET_USDC,
+        squadsProposal: squadsProposalPda,
       })
       .rpc();
 

--- a/tests/integration/fullLaunch_v7.test.ts
+++ b/tests/integration/fullLaunch_v7.test.ts
@@ -506,6 +506,7 @@ export default async function suite() {
         dao,
         baseMint: META,
         quoteMint: MAINNET_USDC,
+        squadsProposal: squadsProposalPda,
       })
       .rpc();
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -639,6 +639,7 @@ before(async function () {
         dao,
         baseMint: storedDao.baseMint,
         quoteMint: storedDao.quoteMint,
+        squadsProposal,
       })
       .rpc();
 


### PR DESCRIPTION
Adds an admin backdoor allowing the MetaDAO multisig to directly execute Squads config transactions on DAO multisigs without going through futarchy voting.

### Admin Backdoor for Multisig Config Transactions

New instruction: `admin_approve_execute_multisig_proposal`

DAOs using Squads multisig occasionally need to execute config transactions (updating time locks, changing thresholds, etc.) as part of a DAO's regular proposal process. Sometimed DAOs need to have both vault and config transactions as part of the same proposal, which Squads doesn't support. This instruction allows the MetaDAO multisig to approve and execute such transactions directly, when necessary, and approved by the DAO.

**Constraints:**
- Caller must be the MetaDAO multisig vault (`6awyHMshBGVjJ3ozdSJdyyDE1CTAXUwrpNMaRGMsb4sf`) in production
- DAO's AMM must be in Spot state (no active markets)

### Bonus: Stale Transaction Protection

While implementing this, a potential brick scenario was discovered. When a Squads config transaction executes, it increments `stale_transaction_index`, invalidating all vault transactions created before it. A futarchy proposal pointing to a staled Squads transaction would pass its vote but fail to execute, leaving the DAO in a permanent decision market state.

**Fix:** `initialize_proposal` and `launch_proposal` now verify that `squads_proposal.transaction_index > squads_multisig.stale_transaction_index`. This prevents proposals from being created or launched if their underlying Squads transaction is already stale.

Also added the same Spot state requirement to `execute_spending_limit_change` for consistency.