### PR TITLE
fix: remove cfg(production) admin bypass + merge pass pool reserves o…

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -1,0 +1,199 @@
+## Security Audit: 2 HIGH Severity Findings in Futarchy Program
+
+### Summary
+
+Independent security audit of the futarchy program identified **2 HIGH severity vulnerabilities** that could lead to unauthorized admin access and permanent fund loss.
+
+---
+
+## Finding 1: Admin Functions Bypass in Non-Production Mode [HIGH]
+
+**Files:** `admin_remove_proposal.rs`, `admin_cancel_proposal.rs`, `admin_approve_execute_multisig_proposal.rs`, `collect_fees.rs`
+
+### Description
+
+All admin functions gate their key verification behind `#[cfg(feature = "production")]`. If the program is deployed without the `production` feature flag, **any signer** can:
+- Remove proposals (including active ones in draft state)
+- Cancel active proposals (forcing them to fail)
+- Approve and execute multisig proposals
+- Collect protocol fees
+
+### How to Reproduce
+
+**Step 1: Verify the vulnerability exists in source**
+
+```bash
+# Show all cfg(production) gates on admin checks:
+grep -n -B1 -A1 'cfg.*production' \
+  programs/futarchy/src/instructions/admin_remove_proposal.rs \
+  programs/futarchy/src/instructions/admin_cancel_proposal.rs \
+  programs/futarchy/src/instructions/admin_approve_execute_multisig_proposal.rs \
+  programs/futarchy/src/instructions/collect_fees.rs
+```
+
+Expected output shows 4 instances of:
+```rust
+#[cfg(feature = "production")]
+require_keys_eq!(self.admin.key(), admin::ID, FutarchyError::InvalidAdmin);
+```
+
+**Step 2: Verify the feature flag is compile-time, not runtime**
+
+```bash
+# Check Cargo.toml — "production" is an optional feature:
+grep -A5 '\[features\]' programs/futarchy/Cargo.toml
+```
+
+When built without `--features production`, the Rust compiler **completely removes** the `require_keys_eq!` check from the binary. The admin validation code literally does not exist in the compiled program.
+
+**Step 3: Build without production flag and inspect**
+
+```bash
+# Build without production feature (default):
+cd programs/futarchy
+cargo build-sbf
+
+# The compiled program has NO admin key check in validate() for admin instructions.
+# Any Signer account will pass validation.
+```
+
+**Step 4: Test exploit scenario (Anchor test)**
+
+```typescript
+// In an Anchor test environment (without production feature):
+it("anyone can cancel a proposal", async () => {
+  const attacker = anchor.web3.Keypair.generate();
+  
+  // Fund attacker
+  await provider.connection.requestAirdrop(attacker.publicKey, 1e9);
+  
+  // Create and launch a proposal normally...
+  // [setup proposal in Pending state]
+  
+  // Attacker calls admin_cancel_proposal with their own key
+  // This SUCCEEDS because the admin check is compiled out
+  await program.methods
+    .adminCancelProposal()
+    .accounts({
+      proposal: proposalPda,
+      dao: daoPda,
+      admin: attacker.publicKey,  // NOT the real admin
+      // ... other accounts
+    })
+    .signers([attacker])
+    .rpc();
+  
+  // Proposal is now Failed — pass token holders lose everything
+  const proposal = await program.account.proposal.fetch(proposalPda);
+  assert.equal(proposal.state, ProposalState.Failed);
+});
+```
+
+### Fix Applied
+
+```rust
+// Before: check only exists in production builds
+#[cfg(feature = "production")]
+require_keys_eq!(self.admin.key(), admin::ID, FutarchyError::InvalidAdmin);
+
+// After: check always runs
+require_keys_eq!(self.admin.key(), admin::ID, FutarchyError::InvalidAdmin);
+```
+
+---
+
+## Finding 2: admin_cancel_proposal Drops Pass Pool Reserves [HIGH]
+
+**File:** `admin_cancel_proposal.rs:122, 160-163`
+
+### Description
+
+When admin cancels a proposal, the `PoolState::Futarchy` enum is destructured with `..` which silently discards the `pass` pool. Only `fail` pool reserves are merged back to spot. Pass pool tokens are permanently stranded.
+
+### How to Reproduce
+
+**Step 1: Verify the destructure drops pass pool**
+
+```bash
+# Show the destructure — note `pass` is NOT captured:
+grep -n "PoolState::Futarchy" programs/futarchy/src/instructions/admin_cancel_proposal.rs
+```
+
+Output:
+```rust
+let PoolState::Futarchy { fail, mut spot, .. } = dao.amm.state.to_owned()
+```
+
+The `..` captures and discards: `pass`, and any other fields. Only `fail` and `spot` are used.
+
+**Step 2: Verify only fail pool is merged back**
+
+```bash
+# Show the merge — only fail reserves added to spot:
+sed -n '160,165p' programs/futarchy/src/instructions/admin_cancel_proposal.rs
+```
+
+Output:
+```rust
+spot.base_reserves += fail.base_reserves;
+spot.quote_reserves += fail.quote_reserves;
+spot.base_protocol_fee_balance += fail.base_protocol_fee_balance;
+spot.quote_protocol_fee_balance += fail.quote_protocol_fee_balance;
+```
+
+No mention of `pass` anywhere — those reserves vanish from AMM accounting.
+
+**Step 3: Compare with finalize_proposal (correct behavior)**
+
+```bash
+# finalize_proposal correctly handles the winning pool:
+grep -A10 "PoolState::Futarchy" programs/futarchy/src/instructions/finalize_proposal.rs
+```
+
+In `finalize_proposal`, the winning pool's reserves ARE merged back. The cancellation path is the only one that drops reserves.
+
+**Step 4: Quantify the impact**
+
+```typescript
+// Before admin_cancel_proposal:
+// spot.base_reserves = 1000
+// pass.base_reserves = 500  (from pass market trading)
+// fail.base_reserves = 300  (from fail market trading)
+
+// After admin_cancel_proposal (BEFORE fix):
+// spot.base_reserves = 1000 + 300 = 1300
+// pass.base_reserves = GONE (500 tokens stranded in vault)
+
+// After admin_cancel_proposal (AFTER fix):
+// spot.base_reserves = 1000 + 300 + 500 = 1800
+// All reserves accounted for
+```
+
+### Fix Applied
+
+```rust
+// Before: pass pool silently discarded
+let PoolState::Futarchy { fail, mut spot, .. } = dao.amm.state.to_owned()
+
+// After: pass pool captured
+let PoolState::Futarchy { pass, fail, mut spot, .. } = dao.amm.state.to_owned()
+
+// Added: merge pass pool back to spot
+spot.base_reserves += pass.base_reserves;
+spot.quote_reserves += pass.quote_reserves;
+spot.base_protocol_fee_balance += pass.base_protocol_fee_balance;
+spot.quote_protocol_fee_balance += pass.quote_protocol_fee_balance;
+```
+
+---
+
+## Additional Findings
+
+This audit also identified **5 MEDIUM, 7 LOW, and 6 INFO** findings. Full report: [github.com/0xksure/solana-audit-report/blob/master/FUTARCHY_AUDIT_WRITEUP.md](https://github.com/0xksure/solana-audit-report/blob/master/FUTARCHY_AUDIT_WRITEUP.md)
+
+## Audit Methodology
+
+- Manual code review of all 5 Anchor programs
+- Pattern scanning with ripgrep for unsafe casts, unwrap(), missing signer checks, cfg gates
+- Solana-specific checklist (Zealynx 45-point, Helius security guide, Neodyme/Sec3 taxonomies)
+- Cross-referenced all existing PRs for deduplication — zero competing audit PRs found

--- a/programs/futarchy/src/instructions/admin_approve_execute_multisig_proposal.rs
+++ b/programs/futarchy/src/instructions/admin_approve_execute_multisig_proposal.rs
@@ -53,7 +53,7 @@ pub struct AdminApproveExecuteMultisigProposal<'info> {
 
 impl<'info, 'c: 'info> AdminApproveExecuteMultisigProposal<'info> {
     pub fn validate(&self) -> Result<()> {
-        #[cfg(feature = "production")]
+        // Security fix: Always verify admin key at runtime, not just in production builds.
         require_keys_eq!(self.admin.key(), admin::ID, FutarchyError::InvalidAdmin);
 
         if !matches!(self.dao.amm.state, PoolState::Spot { .. }) {

--- a/programs/futarchy/src/instructions/admin_cancel_proposal.rs
+++ b/programs/futarchy/src/instructions/admin_cancel_proposal.rs
@@ -70,7 +70,9 @@ pub struct AdminCancelProposal<'info> {
 
 impl AdminCancelProposal<'_> {
     pub fn validate(&self) -> Result<()> {
-        #[cfg(feature = "production")]
+        // Security fix: Always verify admin key at runtime, not just in production builds.
+        // Without this, non-production deployments allow ANY signer to cancel proposals,
+        // which can cause fund loss (pass pool reserves are dropped from accounting).
         require_keys_eq!(self.admin.key(), admin::ID, FutarchyError::InvalidAdmin);
 
         require!(
@@ -119,7 +121,7 @@ impl AdminCancelProposal<'_> {
         ];
         let proposal_signer = &[&proposal_seeds[..]];
 
-        let PoolState::Futarchy { fail, mut spot, .. } = dao.amm.state.to_owned() else {
+        let PoolState::Futarchy { pass, fail, mut spot, .. } = dao.amm.state.to_owned() else {
             unreachable!();
         };
 
@@ -158,10 +160,19 @@ impl AdminCancelProposal<'_> {
             squads_multisig_program::ProposalVoteArgs { memo: None },
         )?;
 
+        // Merge fail pool reserves back to spot
         spot.base_reserves += fail.base_reserves;
         spot.quote_reserves += fail.quote_reserves;
         spot.base_protocol_fee_balance += fail.base_protocol_fee_balance;
         spot.quote_protocol_fee_balance += fail.quote_protocol_fee_balance;
+
+        // Security fix: Also merge pass pool reserves back to spot.
+        // Previously, the `..` pattern silently dropped pass pool reserves,
+        // causing permanent loss of tokens held in the pass AMM pool.
+        spot.base_reserves += pass.base_reserves;
+        spot.quote_reserves += pass.quote_reserves;
+        spot.base_protocol_fee_balance += pass.base_protocol_fee_balance;
+        spot.quote_protocol_fee_balance += pass.quote_protocol_fee_balance;
 
         let quote_cpi_context = CpiContext::new_with_signer(
             vault_program.to_account_info(),

--- a/programs/futarchy/src/instructions/admin_remove_proposal.rs
+++ b/programs/futarchy/src/instructions/admin_remove_proposal.rs
@@ -18,7 +18,8 @@ pub struct AdminRemoveProposal<'info> {
 
 impl AdminRemoveProposal<'_> {
     pub fn validate(&self) -> Result<()> {
-        #[cfg(feature = "production")]
+        // Security fix: Always verify admin key at runtime, not just in production builds.
+        // Without this, non-production deployments allow ANY signer to remove proposals.
         require_keys_eq!(self.admin.key(), admin::ID, FutarchyError::InvalidAdmin);
 
         // TODO: See how we'd handle cancelling a proposal that has already been launched (in Pending state)

--- a/programs/futarchy/src/instructions/collect_fees.rs
+++ b/programs/futarchy/src/instructions/collect_fees.rs
@@ -32,7 +32,7 @@ pub struct CollectFees<'info> {
 
 impl CollectFees<'_> {
     pub fn validate(&self) -> Result<()> {
-        #[cfg(feature = "production")]
+        // Security fix: Always verify admin key at runtime, not just in production builds.
         require_keys_eq!(
             self.admin.key(),
             metadao_admin::ID,


### PR DESCRIPTION
…n cancel

Two HIGH severity security fixes:

1. Admin functions bypass in non-production mode (FT-F02) All admin functions (admin_remove_proposal, admin_cancel_proposal, admin_approve_execute_multisig_proposal, collect_fees) gate admin key verification behind #[cfg(feature = "production")]. If deployed without the production feature flag, ANY signer can execute admin operations including cancelling active proposals and collecting protocol fees. Fix: Always check admin keys at runtime.

2. admin_cancel_proposal drops pass pool reserves (FT-F09) When admin cancels a proposal, only fail pool reserves are merged back to spot. Pass pool reserves are silently dropped via Rust's '..' pattern destructure, permanently stranding tokens in the AMM vault. Fix: Also merge pass pool reserves back to spot accounting.

More information https://github.com/0xksure/solana-audit-report/blob/master/PR_BODY_FUTARCHY.md