### PR TITLE
chore: move output ATA creation from conditionalSwap SDK to callers

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metadaoproject/futarchy",
-  "version": "0.7.3-alpha.1",
+  "version": "0.7.3-alpha.2",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/sdk/src/v0.7/FutarchyClient.ts
+++ b/sdk/src/v0.7/FutarchyClient.ts
@@ -574,15 +574,7 @@ export class FutarchyClient {
           this.vaultClient.vaultProgram.programId,
         )[0],
         question,
-      })
-      .preInstructions([
-        createAssociatedTokenAccountIdempotentInstruction(
-          payer,
-          getAssociatedTokenAddressSync(outputMint, trader, true),
-          trader,
-          outputMint,
-        ),
-      ]);
+      });
   }
 
   squadsProposalCreateTx({

--- a/tests/futarchy/unit/collectFees.test.ts
+++ b/tests/futarchy/unit/collectFees.test.ts
@@ -185,6 +185,13 @@ export default function suite() {
         ],
       });
 
+    const { failQuoteMint } = this.futarchy.getProposalPdas(
+      proposal,
+      META,
+      USDC,
+      dao,
+    );
+
     await this.conditionalVault
       .splitTokensIx(question, baseVault, META, new BN(5 * 10 ** 6), 2)
       .rpc();
@@ -204,6 +211,18 @@ export default function suite() {
         inputAmount: new BN(1),
         minOutputAmount: new BN(0),
       })
+      .preInstructions([
+        createAssociatedTokenAccountIdempotentInstruction(
+          this.payer.publicKey,
+          getAssociatedTokenAddressSync(
+            failQuoteMint,
+            this.payer.publicKey,
+            true,
+          ),
+          this.payer.publicKey,
+          failQuoteMint,
+        ),
+      ])
       .rpc();
 
     const callbacks = expectError(

--- a/tests/futarchy/unit/conditionalSwap.test.ts
+++ b/tests/futarchy/unit/conditionalSwap.test.ts
@@ -4,6 +4,10 @@ import {
   PublicKey,
   TransactionMessage,
 } from "@solana/web3.js";
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+} from "@solana/spl-token";
 import { expectError, setupBasicDao } from "../../utils.js";
 import { BN } from "bn.js";
 import { assert } from "chai";
@@ -59,7 +63,20 @@ export default function suite() {
         market: "pass",
         swapType: "buy",
         inputAmount: new BN(10 * 10 ** 6), // 1 USDC
+        minOutputAmount: new BN(0),
       })
+      .preInstructions([
+        createAssociatedTokenAccountIdempotentInstruction(
+          this.payer.publicKey,
+          getAssociatedTokenAddressSync(
+            passBaseMint,
+            this.payer.publicKey,
+            true,
+          ),
+          this.payer.publicKey,
+          passBaseMint,
+        ),
+      ])
       .rpc();
 
     const postAmmState = (await this.futarchy.getDao(dao)).amm;
@@ -115,7 +132,20 @@ export default function suite() {
         market: "fail",
         swapType: "buy",
         inputAmount: new BN(10 * 10 ** 6), // 1 META
+        minOutputAmount: new BN(0),
       })
+      .preInstructions([
+        createAssociatedTokenAccountIdempotentInstruction(
+          this.payer.publicKey,
+          getAssociatedTokenAddressSync(
+            failBaseMint,
+            this.payer.publicKey,
+            true,
+          ),
+          this.payer.publicKey,
+          failBaseMint,
+        ),
+      ])
       .rpc();
 
     const postFailQuoteBalance = await this.getTokenBalance(
@@ -144,6 +174,13 @@ export default function suite() {
         ],
       });
 
+    const { passBaseMint } = this.futarchy.getProposalPdas(
+      proposal,
+      META,
+      USDC,
+      dao,
+    );
+
     // Split some tokens to have conditional tokens to trade
     await this.conditionalVault
       .splitTokensIx(question, quoteVault, USDC, new BN(5 * 10 ** 6), 2)
@@ -164,7 +201,20 @@ export default function suite() {
         market: "pass",
         swapType: "buy",
         inputAmount: new BN(1000 * 10 ** 6), // 1000 USDC (more than we have)
+        minOutputAmount: new BN(0),
       })
+      .preInstructions([
+        createAssociatedTokenAccountIdempotentInstruction(
+          this.payer.publicKey,
+          getAssociatedTokenAddressSync(
+            passBaseMint,
+            this.payer.publicKey,
+            true,
+          ),
+          this.payer.publicKey,
+          passBaseMint,
+        ),
+      ])
       .rpc()
       .then(callbacks[0], callbacks[1]);
   });
@@ -182,6 +232,13 @@ export default function suite() {
         ],
       });
 
+    const { passQuoteMint } = this.futarchy.getProposalPdas(
+      proposal,
+      META,
+      USDC,
+      dao,
+    );
+
     // Split some tokens to have conditional tokens to trade
     await this.conditionalVault
       .splitTokensIx(question, baseVault, META, new BN(5 * 10 ** 6), 2)
@@ -198,9 +255,6 @@ export default function suite() {
         inputAmount: new BN(100 * 10 ** 6),
       })
       .rpc();
-
-    // Ensure user has USDC token account for input (already created in beforeEach)
-    // await this.createTokenAccount(USDC, this.payer.publicKey);
 
     // Finalize the proposal first
     await this.futarchy
@@ -227,7 +281,20 @@ export default function suite() {
         market: "pass",
         swapType: "sell",
         inputAmount: new BN(1 * 10 ** 6),
+        minOutputAmount: new BN(0),
       })
+      .preInstructions([
+        createAssociatedTokenAccountIdempotentInstruction(
+          this.payer.publicKey,
+          getAssociatedTokenAddressSync(
+            passQuoteMint,
+            this.payer.publicKey,
+            true,
+          ),
+          this.payer.publicKey,
+          passQuoteMint,
+        ),
+      ])
       .rpc()
       .then(callbacks[0], callbacks[1]);
   });
@@ -245,13 +312,17 @@ export default function suite() {
         ],
       });
 
+    const { passQuoteMint } = this.futarchy.getProposalPdas(
+      proposal,
+      META,
+      USDC,
+      dao,
+    );
+
     // Split some tokens to have conditional tokens to trade
     await this.conditionalVault
       .splitTokensIx(question, baseVault, META, new BN(5 * 10 ** 6), 2)
       .rpc();
-
-    // Ensure user has USDC token account for input (already created in beforeEach)
-    // await this.createTokenAccount(USDC, this.payer.publicKey);
 
     const callbacks = expectError(
       "SwapSlippageExceeded",
@@ -270,6 +341,18 @@ export default function suite() {
         inputAmount: new BN(1 * 10 ** 6), // 1 META
         minOutputAmount: new BN(1000 * 10 ** 6), // Expect 1000 USDC (unrealistic)
       })
+      .preInstructions([
+        createAssociatedTokenAccountIdempotentInstruction(
+          this.payer.publicKey,
+          getAssociatedTokenAddressSync(
+            passQuoteMint,
+            this.payer.publicKey,
+            true,
+          ),
+          this.payer.publicKey,
+          passQuoteMint,
+        ),
+      ])
       .rpc()
       .then(callbacks[0], callbacks[1]);
   });

--- a/tests/futarchy/unit/executeSpendingLimitChange.test.ts
+++ b/tests/futarchy/unit/executeSpendingLimitChange.test.ts
@@ -8,6 +8,10 @@ import {
   Transaction,
   TransactionMessage,
 } from "@solana/web3.js";
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+} from "@solana/spl-token";
 import BN from "bn.js";
 import { expectError, setupBasicDao } from "../../utils.js";
 import { assert } from "chai";
@@ -77,12 +81,8 @@ export default function suite() {
     proposal = proposalResult.proposal;
     squadsProposal = proposalResult.squadsProposal;
 
-    const { question, quoteVault } = this.futarchy.getProposalPdas(
-      proposal,
-      META,
-      USDC,
-      dao,
-    );
+    const { question, quoteVault, passBaseMint } =
+      this.futarchy.getProposalPdas(proposal, META, USDC, dao);
 
     await this.conditionalVault
       .splitTokensIx(question, quoteVault, USDC, new BN(11_000 * 1_000_000), 2)
@@ -100,6 +100,18 @@ export default function suite() {
         inputAmount: new BN(10_000 * 1_000_000),
         minOutputAmount: new BN(0),
       })
+      .preInstructions([
+        createAssociatedTokenAccountIdempotentInstruction(
+          this.payer.publicKey,
+          getAssociatedTokenAddressSync(
+            passBaseMint,
+            this.payer.publicKey,
+            true,
+          ),
+          this.payer.publicKey,
+          passBaseMint,
+        ),
+      ])
       .rpc();
 
     // Crank TWAP to build up price history
@@ -190,12 +202,8 @@ export default function suite() {
     proposal = proposalResult.proposal;
     squadsProposal = proposalResult.squadsProposal;
 
-    const { question, quoteVault } = this.futarchy.getProposalPdas(
-      proposal,
-      META,
-      USDC,
-      dao,
-    );
+    const { question, quoteVault, passBaseMint } =
+      this.futarchy.getProposalPdas(proposal, META, USDC, dao);
 
     await this.conditionalVault
       .splitTokensIx(question, quoteVault, USDC, new BN(11_000 * 1_000_000), 2)
@@ -213,6 +221,18 @@ export default function suite() {
         inputAmount: new BN(10_000 * 1_000_000),
         minOutputAmount: new BN(0),
       })
+      .preInstructions([
+        createAssociatedTokenAccountIdempotentInstruction(
+          this.payer.publicKey,
+          getAssociatedTokenAddressSync(
+            passBaseMint,
+            this.payer.publicKey,
+            true,
+          ),
+          this.payer.publicKey,
+          passBaseMint,
+        ),
+      ])
       .rpc();
 
     // Crank TWAP to build up price history
@@ -309,12 +329,8 @@ export default function suite() {
     proposal = proposalResult.proposal;
     squadsProposal = proposalResult.squadsProposal;
 
-    const { question, quoteVault } = this.futarchy.getProposalPdas(
-      proposal,
-      META,
-      USDC,
-      dao,
-    );
+    const { question, quoteVault, passBaseMint } =
+      this.futarchy.getProposalPdas(proposal, META, USDC, dao);
 
     await this.conditionalVault
       .splitTokensIx(question, quoteVault, USDC, new BN(11_000 * 1_000_000), 2)
@@ -332,6 +348,18 @@ export default function suite() {
         inputAmount: new BN(10_000 * 1_000_000),
         minOutputAmount: new BN(0),
       })
+      .preInstructions([
+        createAssociatedTokenAccountIdempotentInstruction(
+          this.payer.publicKey,
+          getAssociatedTokenAddressSync(
+            passBaseMint,
+            this.payer.publicKey,
+            true,
+          ),
+          this.payer.publicKey,
+          passBaseMint,
+        ),
+      ])
       .rpc();
 
     // Crank TWAP to build up price history

--- a/tests/futarchy/unit/finalizeProposal.test.ts
+++ b/tests/futarchy/unit/finalizeProposal.test.ts
@@ -8,6 +8,10 @@ import {
   Transaction,
   TransactionMessage,
 } from "@solana/web3.js";
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+} from "@solana/spl-token";
 import BN from "bn.js";
 import { expectError, setupBasicDao } from "../../utils.js";
 import { assert } from "chai";
@@ -246,12 +250,8 @@ export default function suite() {
   });
 
   it("fails proposals when Pass TWAP < Fail TWAP", async function () {
-    const { quoteVault, question } = this.futarchy.getProposalPdas(
-      proposal,
-      META,
-      USDC,
-      dao,
-    );
+    const { quoteVault, question, passBaseMint } =
+      this.futarchy.getProposalPdas(proposal, META, USDC, dao);
 
     await this.conditionalVault
       .splitTokensIx(question, quoteVault, USDC, new BN(11_000 * 1_000_000), 2)
@@ -271,6 +271,16 @@ export default function suite() {
         })
         .preInstructions([
           ComputeBudgetProgram.setComputeUnitPrice({ microLamports: i }),
+          createAssociatedTokenAccountIdempotentInstruction(
+            this.payer.publicKey,
+            getAssociatedTokenAddressSync(
+              passBaseMint,
+              this.payer.publicKey,
+              true,
+            ),
+            this.payer.publicKey,
+            passBaseMint,
+          ),
         ])
         .rpc();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,7 +975,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@metadaoproject/futarchy@./sdk":
-  version "0.7.3-alpha.1"
+  version "0.7.3-alpha.2"
   dependencies:
     "@coral-xyz/anchor" "^0.29.0"
     "@metaplex-foundation/umi" "^0.9.2"


### PR DESCRIPTION
## Summary

Removes the automatic output ATA (Associated Token Account) creation from `conditionalSwapIx` in the SDK, requiring callers to create the output token account themselves before invoking the swap.