### PR TITLE
harden user-reachable panics in on-chain programs

### DIFF
--- a/programs/bid_wall/src/instructions/sell_tokens.rs
+++ b/programs/bid_wall/src/instructions/sell_tokens.rs
@@ -99,8 +99,11 @@ impl SellTokens<'_> {
 
         // We work under the assumption that the total supply is 10M tokens
         // We then assume that base tokens are only burned by the bid wall.
-        let remaining_base =
-            (TOKENS_TO_PARTICIPANTS - ctx.accounts.bid_wall.base_bought_amount) as u128;
+        let remaining_base = (TOKENS_TO_PARTICIPANTS
+            .checked_sub(ctx.accounts.bid_wall.base_bought_amount)
+            .ok_or(BidWallError::BidWallDepleted)?) as u128;
+
+        require_gt!(remaining_base, 0u128, BidWallError::BidWallDepleted);
 
         let amount_out_before_fee =
             (amount_in as u128 * total_nav as u128 / remaining_base as u128) as u64;

--- a/programs/futarchy/src/instructions/execute_spending_limit_change.rs
+++ b/programs/futarchy/src/instructions/execute_spending_limit_change.rs
@@ -65,7 +65,13 @@ impl<'info, 'c: 'info> ExecuteSpendingLimitChange<'info> {
                 FutarchyError::InvalidTransaction
             );
 
-            let discriminator: [u8; 8] = instruction.data[0..8].try_into().unwrap();
+            require!(
+                instruction.data.len() >= 8,
+                FutarchyError::InvalidTransaction
+            );
+            let discriminator: [u8; 8] = instruction.data[0..8]
+                .try_into()
+                .map_err(|_| error!(FutarchyError::InvalidTransaction))?;
             if discriminator != squads_multisig_program::instruction::MultisigAddSpendingLimit::DISCRIMINATOR &&
                 discriminator != squads_multisig_program::instruction::MultisigRemoveSpendingLimit::DISCRIMINATOR {
                 return Err(error!(FutarchyError::InvalidTransaction));

--- a/programs/futarchy/src/state/futarchy_amm.rs
+++ b/programs/futarchy/src/state/futarchy_amm.rs
@@ -705,10 +705,15 @@ pub fn arbitrage_after_spot_swap(
         (0, final_fail_output - final_conditional_output)
     };
 
-    assert!(final_conditional_output >= best_input_amount);
-    assert_eq!(
+    require_gte!(
+        final_conditional_output,
+        best_input_amount,
+        FutarchyError::InvariantViolated
+    );
+    require_eq!(
         final_conditional_output - best_input_amount,
-        best_profit as u64
+        best_profit as u64,
+        FutarchyError::InvariantViolated
     );
 
     Ok(ArbitrageResult {
@@ -849,7 +854,11 @@ pub fn arbitrage_after_conditional_swap(
         0
     };
 
-    assert!(final_spot_output >= best_arb_input_amount);
+    require_gte!(
+        final_spot_output,
+        best_arb_input_amount,
+        FutarchyError::InvariantViolated
+    );
     let spot_profit = final_spot_output - best_arb_input_amount;
 
     // assert_eq!(final_spot_output - best_input_amount, best_profit as u64);

--- a/programs/v07_launchpad/src/instructions/refund.rs
+++ b/programs/v07_launchpad/src/instructions/refund.rs
@@ -62,10 +62,11 @@ impl Refund<'_> {
 
         let amount_to_refund = match launch.state {
             LaunchState::Refunding => funding_record.committed_amount,
-            LaunchState::Complete => {
-                funding_record.committed_amount - funding_record.approved_amount
-            }
-            _ => unreachable!(),
+            LaunchState::Complete => funding_record
+                .committed_amount
+                .checked_sub(funding_record.approved_amount)
+                .ok_or(LaunchpadError::InvariantViolated)?,
+            _ => return Err(LaunchpadError::InvalidLaunchState.into()),
         };
 
         let seeds = &[


### PR DESCRIPTION
## summary

made by mooncitydev

this PR hardens a handful of on-chain code paths where a user (or an unlucky edge case in state) can trigger a rust panic instead of a clean anchor error. panics consume all remaining compute, dump an ugly `Program log: panicked at ...` line, and are generally a worse failure mode than a typed program error. none of these changes alter the happy path semantics — they just convert `assert!` / `unwrap()` / unchecked subtraction into `require!` / `checked_sub` with an appropriate error.

## what changed

- **`programs/futarchy/src/state/futarchy_amm.rs`** — `arbitrage_after_spot_swap` and `arbitrage_after_conditional_swap` used `assert!` / `assert_eq!` after the grid-search arb to sanity-check the final output vs. the best grid point. these run on the hot swap path, so any divergence (rounding / precision across `feeless_swap` vs. `simulate_swap`) would panic the entire swap. replaced with `require_gte!` / `require_eq!` returning `FutarchyError::InvariantViolated`.
- **`programs/futarchy/src/instructions/execute_spending_limit_change.rs`** — the inner-instruction discriminator was parsed as `instruction.data[0..8].try_into().unwrap()`. a vault transaction whose inner ix has `data.len() < 8` would panic instead of returning `InvalidTransaction`. added a length check and replaced `unwrap()` with `map_err` returning `InvalidTransaction`.
- **`programs/v07_launchpad/src/instructions/refund.rs`** — on `LaunchState::Complete` the refund did `committed_amount - approved_amount`. if the two ever got inconsistent this would underflow on `u64`. switched to `checked_sub` with `LaunchpadError::InvariantViolated`, and changed the `unreachable!()` arm to a typed `InvalidLaunchState` return as defense-in-depth.
- **`programs/bid_wall/src/instructions/sell_tokens.rs`** — `remaining_base = TOKENS_TO_PARTICIPANTS - base_bought_amount` is used as a divisor. if `base_bought_amount` ever reaches `TOKENS_TO_PARTICIPANTS` this divides by zero; if it ever exceeds it (state corruption) it underflows. switched to `checked_sub` returning `BidWallError::BidWallDepleted` and added an explicit `require_gt!` before the division.

## why

- clean error codes instead of panics → better wallet/client error surfaces.
- removes a small DoS surface where a crafted malformed inner ix (spending limit change) or an unlucky edge case in state can brick an instruction with a panic log instead of a program error.
- all four call sites preserve the same behavioral invariants — if the old assertion / subtraction would have succeeded, the new one still does, bit-for-bit.

## test plan

- [ ] `anchor test` (full suite) — happy paths should be untouched.
- [ ] manual: spending limit change with a vault ix that has `data.len() < 8` now returns `InvalidTransaction` instead of panicking.
- [ ] manual: v07 refund on `Complete` with `approved_amount > committed_amount` (synthetically forced) returns `InvariantViolated` instead of panicking.
- [ ] manual: bid_wall `sell_tokens` when `base_bought_amount == TOKENS_TO_PARTICIPANTS` returns `BidWallDepleted` instead of a division-by-zero panic.