### PR TITLE
Add gated_mint to CI/CD workflows (MET-429)

### DIFF
--- a/.github/workflows/deploy-programs.yaml
+++ b/.github/workflows/deploy-programs.yaml
@@ -18,6 +18,7 @@ on:
           - liquidation
           - mint_governor
           - performance_package_v2
+          - gated_mint
       priority-fee:
         description: "Priority fee in microlamports"
         required: true
@@ -205,6 +206,25 @@ jobs:
     with:
       program: "launchpad_v8"
       override-program-id: "moonDJUoHteKkGATejA5bdJVwJ6V6Dg74gyqyJTx73n"
+      network: "mainnet"
+      deploy: true
+      upload_idl: true
+      verify: true
+      use-squads: true
+      features: "production"
+      priority-fee: ${{ inputs.priority-fee }}
+    secrets:
+      MAINNET_SOLANA_DEPLOY_URL: ${{ secrets.MAINNET_SOLANA_DEPLOY_URL }}
+      MAINNET_DEPLOYER_KEYPAIR: ${{ secrets.MAINNET_DEPLOYER_KEYPAIR }}
+      MAINNET_MULTISIG: ${{ secrets.MAINNET_MULTISIG }}
+      MAINNET_MULTISIG_VAULT: ${{ secrets.MAINNET_MULTISIG_VAULT }}
+
+  gated-mint:
+    if: inputs.program == 'gated_mint'
+    uses: ./.github/workflows/reusable-build.yaml
+    with:
+      program: "gated_mint"
+      override-program-id: "GaTEjZy6eMdHg2BcL8dk3iE78jkJ9sPtyw1q2tMNi8PA"
       network: "mainnet"
       deploy: true
       upload_idl: true

--- a/.github/workflows/generate-verifiable-builds.yaml
+++ b/.github/workflows/generate-verifiable-builds.yaml
@@ -185,3 +185,20 @@ jobs:
         with:
           default_author: github_actions
           message: 'Update launchpad_v8 verifiable build'
+  generate-verifiable-gated-mint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: metadaoproject/anchor-verifiable-build@6d8fc1999ea4b7ff701e8b166903b398741e1c50 # v0.4
+        with:
+          program: gated_mint
+          anchor-version: '0.29.0'
+          solana-cli-version: '1.17.31'
+          features: 'production'
+      - run: 'git pull --rebase'
+      - run: cp target/deploy/gated_mint.so ./verifiable-builds
+      - name: Commit verifiable build back to mainline
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
+        with:
+          default_author: github_actions
+          message: 'Update gated_mint verifiable build'


### PR DESCRIPTION
## Summary

Wires `gated_mint` (`GaTEjZy6eMdHg2BcL8dk3iE78jkJ9sPtyw1q2tMNi8PA`) into CI/CD, following the exact pattern of every other program:

- **`generate-verifiable-builds.yaml`**: new `generate-verifiable-gated-mint` job — builds the verifiable `.so` on every push to `develop`/`production` and commits it to `verifiable-builds/gated_mint.so`.
- **`deploy-programs.yaml`**: `gated_mint` added to the program dropdown + new `gated-mint` job calling `reusable-build.yaml` with `use-squads: true` (Squads multisig as upgrade authority, same secrets as all other programs).

## Note: initial deploy is a one-time manual step

`gated_mint` is **not on mainnet yet**, and the Squads deploy path only handles upgrades of an existing program (precedent: launchpad_v8 was deployed manually before its first workflow run). After this merges and CI commits `verifiable-builds/gated_mint.so`:

1. `solana program deploy` the verifiable `.so` with the `GaTE…` program keypair (deployer as initial upgrade authority)
2. `anchor idl init` + `anchor idl set-authority` → `6awyHMshBGVjJ3ozdSJdyyDE1CTAXUwrpNMaRGMsb4sf` (the CI IDL step skips silently if the IDL account doesn't exist)
3. `solana program set-upgrade-authority` → `6awyHMshBGVjJ3ozdSJdyyDE1CTAXUwrpNMaRGMsb4sf`
4. Dispatch the deploy workflow for `gated_mint` to smoke-test the pipeline (byte-identical no-op upgrade + IDL set + verify PDA)

From then on, all upgrades go through the workflow as usual.

## Verification

- `yarn repo:guard` passes (action SHA pins, `solana-cli-version: 1.17.31` consistency)
- Both YAMLs parse; new blocks are byte-identical to their launchpad_v8 counterparts apart from program name/ID
- `programs/gated_mint/Cargo.toml` has the `production = []` feature required by `features: 'production'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)