### PR TITLE
add gated_mint to CI/CD, bump SDK version

### DIFF
--- a/.github/workflows/deploy-programs.yaml
+++ b/.github/workflows/deploy-programs.yaml
@@ -18,6 +18,7 @@ on:
           - liquidation
           - mint_governor
           - performance_package_v2
+          - gated_mint
       priority-fee:
         description: "Priority fee in microlamports"
         required: true
@@ -205,6 +206,25 @@ jobs:
     with:
       program: "launchpad_v8"
       override-program-id: "moonDJUoHteKkGATejA5bdJVwJ6V6Dg74gyqyJTx73n"
+      network: "mainnet"
+      deploy: true
+      upload_idl: true
+      verify: true
+      use-squads: true
+      features: "production"
+      priority-fee: ${{ inputs.priority-fee }}
+    secrets:
+      MAINNET_SOLANA_DEPLOY_URL: ${{ secrets.MAINNET_SOLANA_DEPLOY_URL }}
+      MAINNET_DEPLOYER_KEYPAIR: ${{ secrets.MAINNET_DEPLOYER_KEYPAIR }}
+      MAINNET_MULTISIG: ${{ secrets.MAINNET_MULTISIG }}
+      MAINNET_MULTISIG_VAULT: ${{ secrets.MAINNET_MULTISIG_VAULT }}
+
+  gated-mint:
+    if: inputs.program == 'gated_mint'
+    uses: ./.github/workflows/reusable-build.yaml
+    with:
+      program: "gated_mint"
+      override-program-id: "GaTEjZy6eMdHg2BcL8dk3iE78jkJ9sPtyw1q2tMNi8PA"
       network: "mainnet"
       deploy: true
       upload_idl: true

--- a/.github/workflows/generate-verifiable-builds.yaml
+++ b/.github/workflows/generate-verifiable-builds.yaml
@@ -185,3 +185,20 @@ jobs:
         with:
           default_author: github_actions
           message: 'Update launchpad_v8 verifiable build'
+  generate-verifiable-gated-mint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: metadaoproject/anchor-verifiable-build@6d8fc1999ea4b7ff701e8b166903b398741e1c50 # v0.4
+        with:
+          program: gated_mint
+          anchor-version: '0.29.0'
+          solana-cli-version: '1.17.31'
+          features: 'production'
+      - run: 'git pull --rebase'
+      - run: cp target/deploy/gated_mint.so ./verifiable-builds
+      - name: Commit verifiable build back to mainline
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
+        with:
+          default_author: github_actions
+          message: 'Update gated_mint verifiable build'

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metadaoproject/programs",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.1-alpha.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,7 +865,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@metadaoproject/programs@./sdk":
-  version "0.1.0-alpha.7"
+  version "0.1.1-alpha.0"
   dependencies:
     "@coral-xyz/anchor" "0.29.0"
     "@noble/hashes" "1.8.0"


### PR DESCRIPTION
Wires gated_mint into both workflows: verifiable builds on push to develop/production, and mainnet deploys via `deploy-programs.yaml`. Also bumps the SDK to `0.1.1-alpha.0`.