### PR TITLE
Update LOYAL token metadata description and add project links

### DIFF
--- a/scripts/assets/LOYAL/LOYAL.json
+++ b/scripts/assets/LOYAL/LOYAL.json
@@ -1,6 +1,15 @@
 {
   "name": "Loyal",
   "symbol": "LOYAL",
-  "description": "Loyal is a Solana-based private decentralized intelligence protocol. It enables full data ownership, auditable and decentralized compute and complete censorship resistance.",
-  "image": "https://raw.githubusercontent.com/metaDAOproject/futarchy/refs/heads/develop/scripts/assets/LOYAL/LOYAL.png"
+  "description": "Loyal is self-custodial agentic finance on Solana. Agents make DeFi safer and simpler to use, and you keep your keys and the final say. Open source and governed by MetaDAO futarchy, with the treasury in a DAO-controlled multisig and protocol fees flowing back to it.",
+  "image": "https://raw.githubusercontent.com/metaDAOproject/futarchy/refs/heads/develop/scripts/assets/LOYAL/LOYAL.png",
+  "external_url": "https://askloyal.com",
+  "extensions": {
+    "website": "https://askloyal.com",
+    "app": "https://app.askloyal.com",
+    "docs": "https://docs.askloyal.com",
+    "twitter": "https://x.com/loyal_hq",
+    "telegram": "https://t.me/loyal_tgchat",
+    "github": "https://github.com/loyal-labs"
+  }
 }


### PR DESCRIPTION
Hi MetaDAO team, this is from the Loyal team.

Our token metadata description in `scripts/assets/LOYAL/LOYAL.json` still carries the positioning we launched with in October 2025. It no longer describes what the product does, and it surfaces on Jupiter, Solscan, Rugcheck and wallet token pages, so it is the copy most traders actually see.

This PR:

- Replaces the `description` with current positioning
- Adds `external_url` and an `extensions` block with our website, app, docs, X, Telegram and GitHub, which the file did not previously have

`name`, `symbol` and `image` are unchanged. `LOYAL.png` is not touched, and the metadata URI stays identical so nothing needs to re-resolve on chain.

Happy to trim this to the description change alone if you would prefer a smaller diff.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates LOYAL’s public token description and adds official project links.
- Replaces the original protocol description with current product and governance positioning.
- Adds a canonical external URL plus website, app, documentation, social, and GitHub links.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified.

The metadata remains valid JSON, the existing metadata URI continues to resolve the changed file, and the added fields do not conflict with any repository validation or publishing contract.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/assets/LOYAL/LOYAL.json | Updates valid static token metadata fields without introducing a concrete schema, publishing, or consumer failure. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Update LOYAL token metadata description ..."](https://github.com/metadaoproject/programs/commit/5cac87385378416638ee0a15aeb3c81c7ca19ca8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50049494)</sub>

<!-- /greptile_comment -->