### PR TITLE
Omit repo guard comment when PR comes from fork

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -117,21 +117,29 @@ jobs:
             fi
           } > body.md
 
+          # Render the same content on the run's Summary page - visible on
+          # fork PRs too, where the comment steps below are skipped.
+          cat body.md >> "$GITHUB_STEP_SUMMARY"
+
           {
             echo "body<<EOF"
             cat body.md
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # Fork PRs get a read-only GITHUB_TOKEN, so the comment steps would 403.
+      # Skip them there - the "Fail if any check failed" step still gates.
       - name: Find existing comment
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: find
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: "<!-- repository-guard -->"
 
       - name: Create or update PR comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.find.outputs.comment-id }}


### PR DESCRIPTION
Always render repo guard comment in run summary

See https://github.com/metaDAOproject/programs/actions/runs/30925405694?pr=483 for example

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The workflow now publishes repository-guard results to the GitHub Actions run summary for every pull request while limiting PR-comment operations to same-repository branches.
- Appends the generated guard report to `GITHUB_STEP_SUMMARY`.
- Skips comment lookup and creation for fork-originated pull requests.
- Leaves the final repository-guard gate active for both fork and same-repository pull requests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains in the changed workflow behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/repo-guard.yml | Adds an unconditional run summary and safely guards both write-comment actions for fork pull requests without affecting the final failure gate. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Omit repo guard comment when PR comes fr..."](https://github.com/metadaoproject/programs/commit/fac3906e4084820145e0d0a85fc82668bc0986e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50102203)</sub>

<!-- /greptile_comment -->